### PR TITLE
fix(mui-badge): add success color type

### DIFF
--- a/packages/badge/src/lib/Badge.tsx
+++ b/packages/badge/src/lib/Badge.tsx
@@ -5,7 +5,7 @@ import type { BadgeProps as MUIBadgeProps } from '@mui/material';
 export interface BadgeProps extends MUIBadgeProps {
   badgeContent?: number;
   children: React.ReactNode;
-  color?: 'primary' | 'error';
+  color?: 'primary' | 'error' | 'success';
 }
 
 export const Badge = ({ children, color = 'error', ...rest }: BadgeProps): JSX.Element => (


### PR DESCRIPTION
We have a use case for the nav where we need to use the `success` color variant