### PR TITLE
feat(mui-menu): add menu component

### DIFF
--- a/apps/element-storybook/.storybook/preview.tsx
+++ b/apps/element-storybook/.storybook/preview.tsx
@@ -1,34 +1,32 @@
-import React from 'react';
-import { ThemeProvider } from '@availity/theme-provider';
 import { themes } from '@storybook/theming';
+import { ThemeProvider } from '@availity/theme-provider';
 
 export const parameters = {
   docs: {
+    controls: {
+      sort: 'requiredFirst',
+    },
     theme: themes.light,
     source: {
       excludeDecorators: true,
-    }
+    },
+  },
+  controls: {
+    sort: 'requiredFirst',
   },
   options: {
     storySort: {
-      order: [
-        'Element',
-        'Contributing',
-        'BS4 Migration',
-        ['Getting Started'],
-        'Design System',
-        'Components'
-      ],
+      order: ['Element', 'Contributing', 'BS4 Migration', ['Getting Started'], 'Design System', 'Components'],
     },
   },
 };
 
-const withThemeProvider = (Story: any) => {
-    return (
-        <ThemeProvider>
-          <Story />
-        </ThemeProvider>
-      );
-  };
+const withThemeProvider = (Story: () => JSX.Element) => {
+  return (
+    <ThemeProvider>
+      <Story />
+    </ThemeProvider>
+  );
+};
 
 export const decorators = [withThemeProvider];

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -20,6 +20,7 @@
     "@availity/mui-divider": "workspace:*",
     "@availity/mui-icon": "workspace:*",
     "@availity/mui-link": "workspace:*",
+    "@availity/mui-menu": "workspace:*",
     "@availity/mui-paper": "workspace:*",
     "@availity/mui-tooltip": "workspace:*",
     "@availity/theme-provider": "workspace:*",

--- a/packages/element/src/index.ts
+++ b/packages/element/src/index.ts
@@ -4,6 +4,7 @@ export * from '@availity/mui-button';
 export * from '@availity/mui-divider';
 export * from '@availity/mui-icon';
 export * from '@availity/mui-link';
+export * from '@availity/mui-menu';
 export * from '@availity/mui-paper';
-export * from '@availity/theme-provider';
 export * from '@availity/mui-tooltip';
+export * from '@availity/theme-provider';

--- a/packages/menu/README.md
+++ b/packages/menu/README.md
@@ -1,0 +1,61 @@
+# @availity/mui-menu
+
+> Availity MUI Menu component to be used with @availity/element design system.
+
+[![Version](https://img.shields.io/npm/v/@availity/mui-menu.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/mui-menu)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/mui-menu.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/mui-menu)
+[![Dependency Status](https://img.shields.io/librariesio/release/npm/@availity/mui-menu?style=for-the-badge)](https://github.com/Availity/element/blob/main/packages/mui-menu/package.json)
+
+## Documentation
+
+This package extends the MUI Menu component: [MUI Menu Docs](https://mui.com/components/menu/)
+
+Live demo and documentation in our [Storybook](https://availity.github.io/element/?path=/docs/components-menu-introduction--docs)
+
+Availity standards for design and usage can be found in the [Availity Design Guide](https://zeroheight.com/2e36e50c7)
+
+## Installation
+
+### Import Through @availity/element (Recommended)
+
+#### NPM
+
+```bash
+npm install @availity/element
+```
+
+#### Yarn
+
+```bash
+yarn add @availity/element
+```
+
+### Direct Import
+
+#### NPM
+
+_This package has a few peer dependencies. Add `@mui/material` & `@emotion/react` to your project if not already installed._
+
+```bash
+npm install @availity/mui-menu
+```
+
+#### Yarn
+
+```bash
+yarn add @availity/mui-menu
+```
+
+### Usage
+
+#### Import through @availity/element
+
+```tsx
+import { Menu } from '@availity/element';
+```
+
+#### Direct import
+
+```tsx
+import { Menu } from '@availity/mui-menu';
+```

--- a/packages/menu/introduction.mdx
+++ b/packages/menu/introduction.mdx
@@ -1,0 +1,7 @@
+import { Markdown } from '@storybook/blocks';
+import { Meta } from '@storybook/addon-docs';
+import ReadMe from './README.md?raw';
+
+<Meta title="Components/Menu/Introduction" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/menu/jest.config.js
+++ b/packages/menu/jest.config.js
@@ -1,0 +1,7 @@
+const global = require('../../jest.config.global');
+
+module.exports = {
+  ...global,
+  displayName: 'menu',
+  coverageDirectory: '../../coverage/menu',
+};

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@availity/mui-menu",
+  "version": "0.0.0",
+  "description": "Availity MUI Menu Component - part of the @availity/element design system",
+  "keywords": [
+    "react",
+    "typescript",
+    "availity",
+    "mui"
+  ],
+  "homepage": "https://availity.github.io/element/?path=/docs/components-menu-introduction--docs",
+  "bugs": {
+    "url": "https://github.com/Availity/element/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Availity/element.git",
+    "directory": "packages/menu"
+  },
+  "license": "MIT",
+  "author": "Availity Developers <AVOSS@availity.com>",
+  "browser": "./dist/index.js",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts",
+    "dev": "tsup src/index.ts --format esm,cjs --watch --dts",
+    "clean": "rm -rf dist",
+    "clean:nm": "rm -rf node_modules",
+    "bundlesize": "bundlesize",
+    "publish": "yarn npm publish --tolerate-republish --access public",
+    "publish:canary": "yarn npm publish --access public --tag canary"
+  },
+  "devDependencies": {
+    "@mui/material": "^5.11.9",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tsup": "^5.12.7",
+    "typescript": "^4.6.4"
+  },
+  "peerDependencies": {
+    "@mui/material": "^5.11.9",
+    "react": ">=16.3.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/menu/project.json
+++ b/packages/menu/project.json
@@ -1,0 +1,41 @@
+{
+  "name": "mui-menu",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/menu/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "options": {
+        "eslintConfig": ".eslintrc.json",
+        "lintFilePatterns": ["packages/menu/**/*.{js,ts}"],
+        "silent": false,
+        "fix": false,
+        "cache": true,
+        "cacheLocation": "./node_modules/.cache/menu/.eslintcache",
+        "maxWarnings": -1,
+        "quiet": false,
+        "noEslintrc": false,
+        "hasTypeAwareRules": true,
+        "cacheStrategy": "metadata"
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/menu"],
+      "options": {
+        "jestConfig": "packages/menu/jest.config.js",
+        "passWithNoTests": true
+      }
+    },
+    "version": {
+      "executor": "@jscutlery/semver:version",
+      "options": {
+        "preset": "conventional",
+        "commitMessageFormat": "chore(${projectName}): release version ${version} [skip ci]",
+        "tagPrefix": "@availity/${projectName}@"
+      }
+    }
+  }
+}

--- a/packages/menu/src/index.ts
+++ b/packages/menu/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/Menu';

--- a/packages/menu/src/lib/Menu.stories.tsx
+++ b/packages/menu/src/lib/Menu.stories.tsx
@@ -1,0 +1,61 @@
+// Each exported component in the package should have its own stories file
+import { useEffect, useRef, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from '@availity/mui-button';
+import { Menu, MenuItem } from './Menu';
+
+const meta: Meta<typeof Menu> = {
+  title: 'Components/Menu/Menu',
+  component: Menu,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+export const _Menu: StoryObj<typeof Menu> = {
+  render: ({ open, ...args }) => {
+    const anchorEl = useRef<HTMLButtonElement>(null);
+    const [controlledOpen, setControlledOpen] = useState(false);
+
+    useEffect(() => {
+      setControlledOpen(open);
+    }, [open]);
+
+    const handleClick = () => {
+      setControlledOpen((prev) => !prev);
+    };
+
+    const handleClose = () => {
+      setControlledOpen(false);
+    };
+
+    return (
+      <>
+        <Button
+          id="basic-button"
+          aria-controls={open ? 'basic-menu' : undefined}
+          aria-haspopup="true"
+          aria-expanded={open ? 'true' : undefined}
+          onClick={handleClick}
+          ref={anchorEl}
+        >
+          Dashboard
+        </Button>
+        <Menu
+          id="basic-menu"
+          anchorEl={anchorEl.current}
+          open={controlledOpen}
+          onClose={handleClose}
+          MenuListProps={{
+            'aria-labelledby': 'basic-button',
+          }}
+          {...args}
+        >
+          <MenuItem onClick={handleClose}>Profile</MenuItem>
+          <MenuItem onClick={handleClose}>My account</MenuItem>
+          <MenuItem onClick={handleClose}>Logout</MenuItem>
+        </Menu>
+      </>
+    );
+  },
+};

--- a/packages/menu/src/lib/Menu.test.tsx
+++ b/packages/menu/src/lib/Menu.test.tsx
@@ -1,0 +1,22 @@
+import { render } from '@testing-library/react';
+import { Menu, MenuItem } from './Menu';
+
+describe('Menu', () => {
+  test('should show menu items', () => {
+    const { getByText } = render(
+      <Menu open>
+        <MenuItem>Test</MenuItem>
+      </Menu>
+    );
+    expect(getByText('Test')).toBeTruthy();
+  });
+
+  test('should hide when not open', () => {
+    const { getByText } = render(
+      <Menu open={false}>
+        <MenuItem>Test</MenuItem>
+      </Menu>
+    );
+    expect(() => getByText('Test')).toThrowError();
+  });
+});

--- a/packages/menu/src/lib/Menu.tsx
+++ b/packages/menu/src/lib/Menu.tsx
@@ -9,7 +9,18 @@ import {
 
 export type MenuProps = Omit<
   MuiMenuProps,
-  'classes' | 'sx' | 'PopoverClasses' | 'BackdropComponent' | 'BackdropProps' | 'onBackdropClick' | 'ref'
+  | 'BackdropComponent'
+  | 'BackdropProps'
+  | 'classes'
+  | 'disableAutoFocusItem'
+  | 'disableEnforceFocus'
+  | 'disableEscapeKeyDown'
+  | 'onBackdropClick'
+  | 'PopoverClasses'
+  | 'ref'
+  | 'sx'
+  | 'TransitionComponent'
+  | 'TransitionProps'
 >;
 
 export const Menu = (props: MenuProps): JSX.Element => {

--- a/packages/menu/src/lib/Menu.tsx
+++ b/packages/menu/src/lib/Menu.tsx
@@ -1,0 +1,29 @@
+import {
+  Menu as MuiMenu,
+  MenuProps as MuiMenuProps,
+  MenuItem as MuiMenuItem,
+  MenuItemProps as MuiMenuItemProps,
+  MenuList as MuiMenuList,
+  MenuListProps as MuiMenuListProps,
+} from '@mui/material';
+
+export type MenuProps = Omit<
+  MuiMenuProps,
+  'classes' | 'sx' | 'PopoverClasses' | 'BackdropComponent' | 'BackdropProps' | 'onBackdropClick' | 'ref'
+>;
+
+export const Menu = (props: MenuProps): JSX.Element => {
+  return <MuiMenu {...props} />;
+};
+
+export type MenuItemProps = MuiMenuItemProps;
+
+export const MenuItem = (props: MenuItemProps) => {
+  return <MuiMenuItem {...props} />;
+};
+
+export type MenuListProps = MuiMenuListProps;
+
+export const MenuList = (props: MenuListProps) => {
+  return <MuiMenuList {...props} />;
+};

--- a/packages/menu/tsconfig.json
+++ b/packages/menu/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules"]
+}

--- a/packages/menu/tsconfig.spec.json
+++ b/packages/menu/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node", "@testing-library/jest-dom"],
+    "allowJs": true
+  },
+  "include": ["**/*.test.js", "**/*.test.ts", "**/*.test.tsx", "**/*.d.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -28,6 +28,7 @@
       "@availity/mui-divider": ["packages/divider/src/index.ts"],
       "@availity/mui-icon": ["packages/icon/src/index.ts"],
       "@availity/mui-link": ["packages/link/src/index.ts"],
+      "@availity/mui-menu": ["packages/menu/src/index.ts"],
       "@availity/mui-paper": ["packages/paper/src/index.ts"],
       "@availity/mui-tooltip": ["packages/tooltip/src/index.ts"],
       "@availity/theme": ["packages/theme/src/index.ts"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,6 +43,7 @@ __metadata:
     "@availity/mui-divider": "workspace:*"
     "@availity/mui-icon": "workspace:*"
     "@availity/mui-link": "workspace:*"
+    "@availity/mui-menu": "workspace:*"
     "@availity/mui-paper": "workspace:*"
     "@availity/mui-tooltip": "workspace:*"
     "@availity/theme-provider": "workspace:*"
@@ -149,6 +150,21 @@ __metadata:
   peerDependencies:
     "@mui/material": ^5.11.9
     "@mui/system": ^5.11.9
+    react: ">=16.3.0"
+  languageName: unknown
+  linkType: soft
+
+"@availity/mui-menu@workspace:*, @availity/mui-menu@workspace:packages/menu":
+  version: 0.0.0-use.local
+  resolution: "@availity/mui-menu@workspace:packages/menu"
+  dependencies:
+    "@mui/material": ^5.11.9
+    react: 18.2.0
+    react-dom: 18.2.0
+    tsup: ^5.12.7
+    typescript: ^4.6.4
+  peerDependencies:
+    "@mui/material": ^5.11.9
     react: ">=16.3.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This adds the Menu, MenuItem, and MenuList components.

I also added to the `preview.tsx` to sort the args in the tables and the controls to have the required props first