### PR TITLE
feat(element-storybook): layouts section

### DIFF
--- a/apps/element-storybook/.storybook/main.ts
+++ b/apps/element-storybook/.storybook/main.ts
@@ -4,7 +4,7 @@ import { StorybookConfig } from '@storybook/react-vite';
 const config: StorybookConfig = {
   stories: [
     '../src/*.mdx',
-    '../src/*.stories.@(js|jsx|ts|tsx)',
+    '../src/**/*.stories.@(js|jsx|ts|tsx|mdx)',
     '../../../packages/*/*.mdx',
     '../../../packages/*/src/lib/*.stories.@(js|jsx|ts|tsx|mdx)',
   ],

--- a/apps/element-storybook/src/layouts/sidebar-tables/HeaderSection.tsx
+++ b/apps/element-storybook/src/layouts/sidebar-tables/HeaderSection.tsx
@@ -1,0 +1,5 @@
+import { Box } from '@mui/material';
+
+export const HeaderSection = (): JSX.Element => {
+  return <Box>Header</Box>;
+};

--- a/apps/element-storybook/src/layouts/sidebar-tables/SearchSection.tsx
+++ b/apps/element-storybook/src/layouts/sidebar-tables/SearchSection.tsx
@@ -1,0 +1,9 @@
+import { Paper } from '@mui/material';
+
+export const SearchSection = (): JSX.Element => {
+  return (
+    <Paper variant="elevation" elevation={0}>
+      Search
+    </Paper>
+  );
+};

--- a/apps/element-storybook/src/layouts/sidebar-tables/SideNavSection.tsx
+++ b/apps/element-storybook/src/layouts/sidebar-tables/SideNavSection.tsx
@@ -1,0 +1,10 @@
+import { Paper } from '@mui/material';
+
+// TabContext & TabPanel logic needed in main Story
+export const SideNavSection = (): JSX.Element => {
+  return (
+    <Paper sx={{ height: '100%' }} variant="elevation" elevation={0}>
+      Side Navigation
+    </Paper>
+  );
+};

--- a/apps/element-storybook/src/layouts/sidebar-tables/SidebarLayout.stories.mdx
+++ b/apps/element-storybook/src/layouts/sidebar-tables/SidebarLayout.stories.mdx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Meta, Source, Unstyled } from '@storybook/blocks';
+import { Box, Container, Grid } from '@mui/material';
+import { ThemeProvider } from '@availity/element';
+import { HeaderSection } from './HeaderSection';
+import { SearchSection } from './SearchSection';
+import { SideNavSection } from './SideNavSection';
+import { TablesSection } from './TablesSection';
+
+<Meta title="Layouts/Sidebar/MDX" />
+
+# Sidebar Layout
+
+*Work In Progress*
+
+<Unstyled>
+<ThemeProvider>
+  <Container maxWidth={false} sx={{bgcolor:'background.canvas', minHeight: '75%', maxHeight: '100%', padding:'1rem'}}>
+    <Container fixed>
+      <HeaderSection/>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sm='auto'>
+          <SideNavSection/>
+        </Grid>
+        <Grid item xs>
+          <div role="tabpanel">
+              <Grid container spacing={2}>
+                <Grid item xs={12}>
+                  <SearchSection/>
+                </Grid>
+                <Grid item xs={12}>
+                  <TablesSection/>
+                </Grid>
+              </Grid>
+          </div>
+          <div role="tabpanel" hidden>
+            future section
+          </div>
+          <div role="tabpanel" hidden>
+            future section
+          </div>
+        </Grid>
+      </Grid>
+    </Container>
+  </Container>
+</ThemeProvider>
+</Unstyled>
+
+<Source code={
+`<ThemeProvider>
+  <Container maxWidth={false} sx={{bgcolor:'background.canvas', padding:'1rem'}}>
+    <Container fixed>
+      <HeaderSection/>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sm='auto'>
+          <SideNavSection/>
+        </Grid>
+        <Grid item xs>
+          <div role="tabpanel">
+              <Grid container spacing={2}>
+                <Grid item xs={12}>
+                  <SearchSection/>
+                </Grid>
+                <Grid item xs={12}>
+                  <TablesSection/>
+                </Grid>
+              </Grid>
+          </div>
+          <div role="tabpanel" hidden>
+            future section
+          </div>
+          <div role="tabpanel" hidden>
+            future section
+          </div>
+        </Grid>
+      </Grid>
+    </Container>
+  </Container>
+</ThemeProvider>
+`} />

--- a/apps/element-storybook/src/layouts/sidebar-tables/SidebarLayout.stories.tsx
+++ b/apps/element-storybook/src/layouts/sidebar-tables/SidebarLayout.stories.tsx
@@ -1,0 +1,71 @@
+import { StoryObj, Meta } from '@storybook/react';
+import { Container, Grid } from '@mui/material';
+import { HeaderSection } from './HeaderSection';
+import { SearchSection } from './SearchSection';
+import { SideNavSection } from './SideNavSection';
+import { TablesSection } from './TablesSection';
+import React from 'react';
+
+/**
+ * *Work In Progress*
+ *
+ * Sidebar layout that includes header, sidenav, search section, & tables. */
+const meta: Meta = {
+  title: 'Layouts/Sidebar',
+  tags: ['autodocs'],
+};
+
+/**  */
+export default meta;
+
+export const _SidebarLayout: StoryObj = {
+  render: () => {
+    // TODO: tab logic
+    return (
+      <Container maxWidth={false} sx={{ bgcolor: 'background.canvas', minHeight: '75%', padding: '1rem' }}>
+        <Container fixed>
+          <HeaderSection />
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm="auto">
+              <SideNavSection />
+            </Grid>
+            <Grid item xs>
+              <div role="tabpanel">
+                <Grid container spacing={2}>
+                  <Grid item xs={12}>
+                    <SearchSection />
+                  </Grid>
+                  <Grid item xs={12}>
+                    <TablesSection />
+                  </Grid>
+                </Grid>
+              </div>
+              <div role="tabpanel" hidden>
+                future section
+              </div>
+              <div role="tabpanel" hidden>
+                future section
+              </div>
+            </Grid>
+          </Grid>
+        </Container>
+      </Container>
+    );
+  },
+};
+
+export const _HeaderSection: StoryObj = {
+  render: () => <HeaderSection />,
+};
+
+export const _SideNavSection: StoryObj = {
+  render: () => <SideNavSection />,
+};
+
+export const _SearchSection: StoryObj = {
+  render: () => <SearchSection />,
+};
+
+export const _TablesSection: StoryObj = {
+  render: () => <TablesSection />,
+};

--- a/apps/element-storybook/src/layouts/sidebar-tables/TablesSection.tsx
+++ b/apps/element-storybook/src/layouts/sidebar-tables/TablesSection.tsx
@@ -1,0 +1,9 @@
+import { Paper } from '@mui/material';
+
+export const TablesSection = (): JSX.Element => {
+  return (
+    <Paper variant="elevation" elevation={0}>
+      Tables
+    </Paper>
+  );
+};


### PR DESCRIPTION
two different versions of documentation given:

1. Autodocs - lists subsections as different stories. Probably better for the interim as we're working. Once all work is done (replaced with availity components) we can move/combine all code into the subsection stories for the corresponding code snippets.
2. MDX - Manual docs, might be better for final documentation once all work is done and combine all code into one file.

thinking of leaving in both for now and deciding which one is best at the end.