### PR TITLE
feat(mui-datepicker): add datepicker component

### DIFF
--- a/packages/datepicker/README.md
+++ b/packages/datepicker/README.md
@@ -1,0 +1,61 @@
+# @availity/mui-datepicker
+
+> Availity MUI Datepicker component to be used with @availity/element design system.
+
+[![Version](https://img.shields.io/npm/v/@availity/mui-datepicker.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/mui-datepicker)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/mui-datepicker.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/mui-datepicker)
+[![Dependency Status](https://img.shields.io/librariesio/release/npm/@availity/mui-datepicker?style=for-the-badge)](https://github.com/Availity/element/blob/main/packages/mui-datepicker/package.json)
+
+## Documentation
+
+This package extends the MUI Datepicker component: [MUI Datepicker Docs](https://mui.com/components/datepicker/)
+
+Live demo and documentation in our [Storybook](https://availity.github.io/element/?path=/docs/components-datepicker-introduction--docs)
+
+Availity standards for design and usage can be found in the [Availity Design Guide](https://zeroheight.com/2e36e50c7)
+
+## Installation
+
+### Import Through @availity/element (Recommended)
+
+#### NPM
+
+```bash
+npm install @availity/element
+```
+
+#### Yarn
+
+```bash
+yarn add @availity/element
+```
+
+### Direct Import
+
+#### NPM
+
+_This package has a few peer dependencies. Add `@mui/material` & `@emotion/react` to your project if not already installed._
+
+```bash
+npm install @availity/mui-datepicker
+```
+
+#### Yarn
+
+```bash
+yarn add @availity/mui-datepicker
+```
+
+### Usage
+
+#### Import through @availity/element
+
+```tsx
+import { Datepicker } from '@availity/element';
+```
+
+#### Direct import
+
+```tsx
+import { Datepicker } from '@availity/mui-datepicker';
+```

--- a/packages/datepicker/introduction.mdx
+++ b/packages/datepicker/introduction.mdx
@@ -1,0 +1,7 @@
+import { Markdown } from '@storybook/blocks';
+import { Meta } from '@storybook/addon-docs';
+import ReadMe from './README.md?raw';
+
+<Meta title="Components/Datepicker/Introduction" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/datepicker/jest.config.js
+++ b/packages/datepicker/jest.config.js
@@ -1,0 +1,7 @@
+const global = require('../../jest.config.global');
+
+module.exports = {
+  ...global,
+  displayName: 'datepicker',
+  coverageDirectory: '../../coverage/datepicker',
+};

--- a/packages/datepicker/package.json
+++ b/packages/datepicker/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@availity/mui-datepicker",
+  "version": "0.0.0",
+  "description": "Availity MUI Datepicker Component - part of the @availity/element design system",
+  "keywords": [
+    "react",
+    "typescript",
+    "availity",
+    "mui"
+  ],
+  "homepage": "https://availity.github.io/element/?path=/docs/components-datepicker-introduction--docs",
+  "bugs": {
+    "url": "https://github.com/Availity/element/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Availity/element.git",
+    "directory": "packages/datepicker"
+  },
+  "license": "MIT",
+  "author": "Availity Developers <AVOSS@availity.com>",
+  "browser": "./dist/index.js",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts",
+    "dev": "tsup src/index.ts --format esm,cjs --watch --dts",
+    "clean": "rm -rf dist",
+    "clean:nm": "rm -rf node_modules",
+    "bundlesize": "bundlesize",
+    "publish": "yarn npm publish --tolerate-republish --access public",
+    "publish:canary": "yarn npm publish --access public --tag canary"
+  },
+  "devDependencies": {
+    "@mui/material": "^5.11.9",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tsup": "^5.12.7",
+    "typescript": "^4.6.4"
+  },
+  "peerDependencies": {
+    "@mui/material": "^5.11.9",
+    "react": ">=16.3.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@mui/x-date-pickers": "^5.0.15",
+    "dayjs": "^1.11.9"
+  }
+}

--- a/packages/datepicker/project.json
+++ b/packages/datepicker/project.json
@@ -1,0 +1,41 @@
+{
+  "name": "mui-datepicker",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/datepicker/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "options": {
+        "eslintConfig": ".eslintrc.json",
+        "lintFilePatterns": ["packages/datepicker/**/*.{js,ts}"],
+        "silent": false,
+        "fix": false,
+        "cache": true,
+        "cacheLocation": "./node_modules/.cache/datepicker/.eslintcache",
+        "maxWarnings": -1,
+        "quiet": false,
+        "noEslintrc": false,
+        "hasTypeAwareRules": true,
+        "cacheStrategy": "metadata"
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/datepicker"],
+      "options": {
+        "jestConfig": "packages/datepicker/jest.config.js",
+        "passWithNoTests": true
+      }
+    },
+    "version": {
+      "executor": "@jscutlery/semver:version",
+      "options": {
+        "preset": "conventional",
+        "commitMessageFormat": "chore(${projectName}): release version ${version} [skip ci]",
+        "tagPrefix": "@availity/${projectName}@"
+      }
+    }
+  }
+}

--- a/packages/datepicker/src/index.ts
+++ b/packages/datepicker/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/Datepicker';

--- a/packages/datepicker/src/lib/Datepicker.stories.tsx
+++ b/packages/datepicker/src/lib/Datepicker.stories.tsx
@@ -1,0 +1,30 @@
+// Each exported component in the package should have its own stories file
+import type { Meta, StoryObj } from '@storybook/react';
+import { Datepicker, DatepickerProps } from './Datepicker';
+import { useState } from 'react';
+import { Dayjs } from 'dayjs';
+
+const meta: Meta<typeof Datepicker> = {
+  title: 'Components/Datepicker/Datepicker',
+  component: Datepicker,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+export const _Datepicker: StoryObj<typeof Datepicker> = {
+  render: (args: DatepickerProps) => {
+    const [value, setValue] = useState<Dayjs | null>(null);
+
+    return (
+      <Datepicker
+        {...args}
+        value={value}
+        onChange={(value) => {
+          setValue(value);
+        }}
+      />
+    );
+  },
+  args: {},
+};

--- a/packages/datepicker/src/lib/Datepicker.test.tsx
+++ b/packages/datepicker/src/lib/Datepicker.test.tsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/react';
+import { Datepicker } from './Datepicker';
+
+describe('Datepicker', () => {
+  test('should render successfully', () => {
+    const { getByText } = render(<Datepicker>Test</Datepicker>);
+    expect(getByText('Test')).toBeTruthy();
+  });
+});

--- a/packages/datepicker/src/lib/Datepicker.test.tsx
+++ b/packages/datepicker/src/lib/Datepicker.test.tsx
@@ -1,9 +1,14 @@
 import { render } from '@testing-library/react';
+import { ThemeProvider } from '@availity/theme-provider';
 import { Datepicker } from './Datepicker';
 
 describe('Datepicker', () => {
   test('should render successfully', () => {
-    const { getByText } = render(<Datepicker>Test</Datepicker>);
-    expect(getByText('Test')).toBeTruthy();
+    const { getAllByText } = render(
+      <ThemeProvider>
+        <Datepicker label="Test" onChange={jest.fn()} value={null} />
+      </ThemeProvider>
+    );
+    expect(getAllByText('Test')).toBeTruthy();
   });
 });

--- a/packages/datepicker/src/lib/Datepicker.tsx
+++ b/packages/datepicker/src/lib/Datepicker.tsx
@@ -1,0 +1,29 @@
+import { TextField } from '@mui/material';
+import { DatePicker as MuiDatePicker, DatePickerProps as MuiDatePickerProps } from '@mui/x-date-pickers/DatePicker';
+import type { Dayjs } from 'dayjs';
+
+export type DatepickerProps = Omit<
+  MuiDatePickerProps<Dayjs, Dayjs>,
+  | 'components'
+  | 'componentsProps'
+  | 'desktopModeMediaQuery'
+  | 'DialogProps'
+  | 'OpenPickerButtonProps'
+  | 'openTo'
+  | 'orientation'
+  | 'PaperProps'
+  | 'PopperProps'
+  | 'reduceAnimations'
+  | 'renderInput'
+  | 'rifmFormatter'
+  | 'showToolbar'
+  | 'ToolbarComponent'
+  | 'toolbarFormat'
+  | 'toolbarPlaceholder'
+  | 'toolbarTitle'
+  | 'TransitionComponent'
+>;
+
+export const Datepicker = (props: DatepickerProps): JSX.Element => {
+  return <MuiDatePicker {...props} renderInput={(params) => <TextField {...params} />} />;
+};

--- a/packages/datepicker/tsconfig.json
+++ b/packages/datepicker/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules"]
+}

--- a/packages/datepicker/tsconfig.spec.json
+++ b/packages/datepicker/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node", "@testing-library/jest-dom"],
+    "allowJs": true
+  },
+  "include": ["**/*.test.js", "**/*.test.ts", "**/*.test.tsx", "**/*.d.ts"]
+}

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -21,6 +21,7 @@
     "@availity/mui-button": "workspace:*",
     "@availity/mui-card": "workspace:*",
     "@availity/mui-chip": "workspace:*",
+    "@availity/mui-datepicker": "workspace:*",
     "@availity/mui-divider": "workspace:*",
     "@availity/mui-icon": "workspace:*",
     "@availity/mui-link": "workspace:*",

--- a/packages/element/src/index.ts
+++ b/packages/element/src/index.ts
@@ -5,6 +5,7 @@ export * from '@availity/mui-breadcrumbs';
 export * from '@availity/mui-button';
 export * from '@availity/mui-card';
 export * from '@availity/mui-chip';
+export * from '@availity/mui-datepicker';
 export * from '@availity/mui-divider';
 export * from '@availity/mui-icon';
 export * from '@availity/mui-link';

--- a/packages/theme-provider/package.json
+++ b/packages/theme-provider/package.json
@@ -20,7 +20,7 @@
     "@emotion/styled": "^11.10.5",
     "@mui/material": "^5.11.6",
     "@mui/x-date-pickers": "^5.0.15",
-    "date-fns": "^2.29.3"
+    "dayjs": "^1.11.9"
   },
   "devDependencies": {
     "react": "18.2.0",

--- a/packages/theme-provider/src/lib/theme-provider.tsx
+++ b/packages/theme-provider/src/lib/theme-provider.tsx
@@ -2,7 +2,7 @@ import { lightTheme } from '@availity/theme';
 import { ThemeProvider as MuiThemeProvider, createTheme } from '@mui/material/styles';
 import type { Theme, ThemeOptions } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 
 // TODO: how do we add icon support?
@@ -17,7 +17,7 @@ export interface ThemeProviderProps {
 
 export function ThemeProvider({ children, theme = defaultTheme }: ThemeProviderProps) {
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
       <MuiThemeProvider theme={theme}>
         <CssBaseline />
         {children}

--- a/packages/theme/src/lib/light-theme.ts
+++ b/packages/theme/src/lib/light-theme.ts
@@ -484,6 +484,28 @@ export const lightTheme = {
         },
       },
     },
+    MuiPickersCalendarHeader: {
+      styleOverrides: {
+        root: {
+          padding: '4px 16px 8px',
+        },
+      },
+    },
+    MuiDayPicker: {
+      styleOverrides: {
+        monthContainer: {
+          padding: '12px 8px 0px',
+        },
+      },
+    },
+    MuiCalendarPicker: {
+      styleOverrides: {
+        root: {
+          height: '328px',
+          width: '310px',
+        },
+      },
+    },
     MuiIconButton: {
       defaultProps: {
         // The props to change the default for.

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -29,6 +29,7 @@
       "@availity/mui-button": ["packages/button/src/index.ts"],
       "@availity/mui-card": ["packages/card/src/index.ts"],
       "@availity/mui-chip": ["packages/chip/src/index.ts"],
+      "@availity/mui-datepicker": ["packages/datepicker/src/index.ts"],
       "@availity/mui-divider": ["packages/divider/src/index.ts"],
       "@availity/mui-icon": ["packages/icon/src/index.ts"],
       "@availity/mui-link": ["packages/link/src/index.ts"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,6 +44,7 @@ __metadata:
     "@availity/mui-button": "workspace:*"
     "@availity/mui-card": "workspace:*"
     "@availity/mui-chip": "workspace:*"
+    "@availity/mui-datepicker": "workspace:*"
     "@availity/mui-divider": "workspace:*"
     "@availity/mui-icon": "workspace:*"
     "@availity/mui-link": "workspace:*"
@@ -167,6 +168,23 @@ __metadata:
   resolution: "@availity/mui-chip@workspace:packages/chip"
   dependencies:
     "@mui/material": ^5.11.9
+    react: 18.2.0
+    react-dom: 18.2.0
+    tsup: ^5.12.7
+    typescript: ^4.6.4
+  peerDependencies:
+    "@mui/material": ^5.11.9
+    react: ">=16.3.0"
+  languageName: unknown
+  linkType: soft
+
+"@availity/mui-datepicker@workspace:*, @availity/mui-datepicker@workspace:packages/datepicker":
+  version: 0.0.0-use.local
+  resolution: "@availity/mui-datepicker@workspace:packages/datepicker"
+  dependencies:
+    "@mui/material": ^5.11.9
+    "@mui/x-date-pickers": ^5.0.15
+    dayjs: ^1.11.9
     react: 18.2.0
     react-dom: 18.2.0
     tsup: ^5.12.7
@@ -303,7 +321,7 @@ __metadata:
     "@emotion/styled": ^11.10.5
     "@mui/material": ^5.11.6
     "@mui/x-date-pickers": ^5.0.15
-    date-fns: ^2.29.3
+    dayjs: ^1.11.9
     react: 18.2.0
     react-dom: 18.2.0
     tsup: ^5.12.7
@@ -7604,19 +7622,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:^2.29.3":
-  version: 2.30.0
-  resolution: "date-fns@npm:2.30.0"
-  dependencies:
-    "@babel/runtime": ^7.21.0
-  checksum: f7be01523282e9bb06c0cd2693d34f245247a29098527d4420628966a2d9aad154bd0e90a6b1cf66d37adcb769cd108cf8a7bd49d76db0fb119af5cdd13644f4
-  languageName: node
-  linkType: hard
-
 "dateformat@npm:^3.0.0":
   version: 3.0.3
   resolution: "dateformat@npm:3.0.3"
   checksum: ca4911148abb09887bd9bdcd632c399b06f3ecad709a18eb594d289a1031982f441e08e281db77ffebcb2cbcbfa1ac578a7cbfbf8743f41009aa5adc1846ed34
+  languageName: node
+  linkType: hard
+
+"dayjs@npm:^1.11.9":
+  version: 1.11.9
+  resolution: "dayjs@npm:1.11.9"
+  checksum: a4844d83dc87f921348bb9b1b93af851c51e6f71fa259604809cfe1b49d1230e6b0212dab44d1cb01994c096ad3a77ea1cf18fa55154da6efcc9d3610526ac38
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add the `Datepicker` component. We will need to update the `renderInput` prop once the `TextField` component is available.