### PR TITLE
fix(theme): remove focus on datepicker icon button

### DIFF
--- a/packages/theme/src/lib/light-theme.ts
+++ b/packages/theme/src/lib/light-theme.ts
@@ -820,9 +820,6 @@ export const lightTheme = {
           '&:hover': {
             backgroundColor: tokens.colorActionHover,
           },
-          '&:focus': {
-            backgroundColor: tokens.colorActionFocus,
-          },
         },
         colorPrimary: {
           borderColor: tokens.borderPrimary,


### PR DESCRIPTION
Removes focus on calendar icon when selecting a date with the mouse