### PR TITLE
fix(mui-breadcrumbs): set default target on link to _top

### DIFF
--- a/packages/breadcrumbs/src/lib/Breadcrumbs.test.tsx
+++ b/packages/breadcrumbs/src/lib/Breadcrumbs.test.tsx
@@ -104,5 +104,39 @@ describe('Breadcrumbs', () => {
       expect(currentPageBreadcrumb).not.toHaveAttribute('href');
       expect(currentPageBreadcrumb).toHaveTextContent('...');
     });
+
+    test('crumb should have default target of _top', () => {
+      const { getByTestId } = render(
+        <Breadcrumbs
+          data-testid="testBreadcrumbs"
+          crumbs={[
+            { name: 'Grand Parent', url: '/grandparent' },
+            { name: 'Parent', url: '/grandparent/parent' },
+          ]}
+        />
+      );
+
+      const breadcrumbs = getByTestId('testBreadcrumbs').getElementsByClassName('MuiBreadcrumbs-li');
+      const grandparentBreadcrumb = breadcrumbs[1].getElementsByTagName('a')[0];
+
+      expect(grandparentBreadcrumb).toHaveAttribute('target', '_top');
+    });
+
+    test('crumb should set target to what is passed in config', () => {
+      const { getByTestId } = render(
+        <Breadcrumbs
+          data-testid="testBreadcrumbs"
+          crumbs={[
+            { name: 'Grand Parent', url: '/grandparent', target: '_self' },
+            { name: 'Parent', url: '/grandparent/parent' },
+          ]}
+        />
+      );
+
+      const breadcrumbs = getByTestId('testBreadcrumbs').getElementsByClassName('MuiBreadcrumbs-li');
+      const grandparentBreadcrumb = breadcrumbs[1].getElementsByTagName('a')[0];
+
+      expect(grandparentBreadcrumb).toHaveAttribute('target', '_self');
+    });
   });
 });

--- a/packages/breadcrumbs/src/lib/Breadcrumbs.tsx
+++ b/packages/breadcrumbs/src/lib/Breadcrumbs.tsx
@@ -7,6 +7,10 @@ interface Crumb {
   name: string;
   /** The url for navigating to the ancestor page. */
   url: string;
+  /** The target on the Link component
+   * @default _top
+   */
+  target?: string;
 }
 
 export interface BreadcrumbsProps extends Omit<MuiBreadcrumbsProps, 'separator' | 'slotProps' | 'slots'> {
@@ -26,10 +30,11 @@ export interface BreadcrumbsProps extends Omit<MuiBreadcrumbsProps, 'separator' 
   homeUrl?: string;
 }
 
-const Breadcrumb = ({ name, url }: Crumb) => {
+const Breadcrumb = ({ name, url, target = '_top' }: Crumb) => {
   const props = {
     'aria-label': name,
     children: name,
+    target,
   };
 
   return url ? <Link {...props} href={url} /> : <Typography {...props} />;
@@ -55,7 +60,9 @@ export const Breadcrumbs = ({
       </Link>
       {crumbs &&
         crumbs.length > 0 &&
-        crumbs.map(({ name = emptyState, url }) => <Breadcrumb name={name} url={url} key={name} />)}
+        crumbs.map(({ name = emptyState, url, target }) => (
+          <Breadcrumb name={name} url={url} target={target} key={name} />
+        ))}
       {children}
       <Typography>{active || emptyState}</Typography>
     </MuiBreadcrumbs>

--- a/packages/breadcrumbs/src/lib/Breadcrumbs.tsx
+++ b/packages/breadcrumbs/src/lib/Breadcrumbs.tsx
@@ -34,10 +34,9 @@ const Breadcrumb = ({ name, url, target = '_top' }: Crumb) => {
   const props = {
     'aria-label': name,
     children: name,
-    target,
   };
 
-  return url ? <Link {...props} href={url} /> : <Typography {...props} />;
+  return url ? <Link {...props} href={url} target={target} /> : <Typography {...props} />;
 };
 
 export const Breadcrumbs = ({


### PR DESCRIPTION
Sets the default of `target` to `_top` for breadcrumbs. This is because we assume the crumbs will be used in the portal. This can be overridden through the config passed to the `crumbs` prop