### PR TITLE
fix(theme): add modal legacy styles

### DIFF
--- a/packages/theme/src/lib/legacy-theme.ts
+++ b/packages/theme/src/lib/legacy-theme.ts
@@ -810,6 +810,28 @@ export const legacyTheme = {
         },
       },
     },
+    MuiDialogTitle: {
+      styleOverrides: {
+        root: {
+          backgroundColor: tokens.colorGrey100,
+          marginBottom: '24px',
+        },
+      },
+    },
+    MuiDialogContent: {
+      styleOverrides: {
+        root: {
+          padding: '24px',
+        },
+      },
+    },
+    MuiDialogActions: {
+      styleOverrides: {
+        root: {
+          backgroundColor: tokens.colorGrey100,
+        },
+      },
+    },
     // v5 Datepicker, MuiDayCalendar in v6
     MuiDayPicker: {
       styleOverrides: {
@@ -1254,6 +1276,7 @@ export const legacyTheme = {
     },
     MuiPopover: {
       defaultProps: {
+        elevation: 0,
         PaperProps: {
           variant: 'outlined',
         },


### PR DESCRIPTION
Fixes an issue with the Popover using legacy theme where the elevation should default to 0.

Adds back legacy modal styles with the Dialog.