### PR TITLE
fix(mui-block-ui): pass className

### DIFF
--- a/packages/block-ui/src/lib/BlockUi.tsx
+++ b/packages/block-ui/src/lib/BlockUi.tsx
@@ -81,7 +81,6 @@ export type BlockUiProps = {
 export function BlockUi({
   blocking,
   children,
-  className = '',
   keepInView,
   loader = <Loader />,
   message,


### PR DESCRIPTION
pass `className` to root component