### PR TITLE
fix: add export and delay

### DIFF
--- a/apps/element-storybook/tsconfig.storybook.json
+++ b/apps/element-storybook/tsconfig.storybook.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "../../",
+    "composite": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "outDir": ""
@@ -18,8 +20,9 @@
     "src/*.stories.ts",
     "src/*.stories.js",
     "src/*.stories.jsx",
-    "src/*.stories.tsx",
+    "src/**/*.stories.tsx",
     "src/*.stories.mdx",
+    "../../packages/*/src/*.ts",
     "../../packages/*.stories.mdx",
     "../../packages/*/src/lib/*.stories.js",
     "../../packages/*/src/lib/*.stories.jsx",

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -36,6 +36,9 @@
     "@mui/types": "^7.2.14"
   },
   "devDependencies": {
+    "@availity/api-axios": "^8.0.7",
+    "@availity/mui-form-utils": "workspace:^",
+    "@availity/mui-textfield": "workspace:^",
     "@mui/material": "^5.15.15",
     "react": "18.2.0",
     "react-dom": "18.2.0",
@@ -43,6 +46,7 @@
     "typescript": "^5.4.5"
   },
   "peerDependencies": {
+    "@availity/api-axios": "^8.0.7",
     "@availity/mui-form-utils": "workspace:^",
     "@availity/mui-textfield": "workspace:^",
     "@mui/material": "^5.11.9",

--- a/packages/autocomplete/src/index.ts
+++ b/packages/autocomplete/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/Autocomplete';
 export * from './lib/AsyncAutocomplete';
+export * from './lib/OrganizationAutocomplete';

--- a/packages/autocomplete/src/lib/OrganizationAutocomplete.tsx
+++ b/packages/autocomplete/src/lib/OrganizationAutocomplete.tsx
@@ -27,15 +27,15 @@ const fetchOrgs = async (config: ApiConfig): Promise<{ options: Organization[]; 
   }
 };
 
-export type OrgAutocompleteProps<
+export interface OrgAutocompleteProps<
   Option = Organization,
   Multiple extends boolean | undefined = false,
   DisableClearable extends boolean | undefined = false,
   FreeSolo extends boolean | undefined = false,
   ChipComponent extends React.ElementType = ChipTypeMap['defaultComponent'],
-> = {
+> extends Omit<AsyncAutocompleteProps<Option, Multiple, DisableClearable, FreeSolo, ChipComponent>, 'loadOptions'> {
   apiConfig?: ApiConfig;
-} & Omit<AsyncAutocompleteProps<Option, Multiple, DisableClearable, FreeSolo, ChipComponent>, 'loadOptions'>;
+}
 
 export const OrganizationAutocomplete = ({ apiConfig = {}, ...rest }: OrgAutocompleteProps) => {
   const handleLoadOptions = async (page: number, limit: number) => {

--- a/packages/mock/src/lib/handlers.ts
+++ b/packages/mock/src/lib/handlers.ts
@@ -126,6 +126,8 @@ export const handlers = [
       parsedParams[key] = parsers[key]?.(value) ?? value;
     }
 
+    await delay(defaultDelay);
+
     if (typeof parsedParams.offset !== 'number' || typeof parsedParams.limit !== 'number') {
       throw new Error('offset and limit not provided');
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -208,6 +208,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@availity/mui-autocomplete@workspace:packages/autocomplete"
   dependencies:
+    "@availity/api-axios": ^8.0.7
+    "@availity/mui-form-utils": "workspace:^"
+    "@availity/mui-textfield": "workspace:^"
     "@mui/material": ^5.15.15
     "@mui/types": ^7.2.14
     react: 18.2.0
@@ -215,6 +218,7 @@ __metadata:
     tsup: ^8.0.2
     typescript: ^5.4.5
   peerDependencies:
+    "@availity/api-axios": ^8.0.7
     "@availity/mui-form-utils": "workspace:^"
     "@availity/mui-textfield": "workspace:^"
     "@mui/material": ^5.11.9


### PR DESCRIPTION
Add export for `OrganizationAutocomplete` and a delay to the mock handler