### PR TITLE
fix(mui-datepicker): accessible dialog name and other updates

### DIFF
--- a/packages/datepicker/package.json
+++ b/packages/datepicker/package.json
@@ -32,6 +32,7 @@
     "publish:canary": "yarn npm publish --access public --tag canary"
   },
   "dependencies": {
+    "@availity/mui-icon": "workspace:*",
     "@availity/mui-textfield": "workspace:*",
     "@mui/x-date-pickers": "^7.2.0",
     "dayjs": "^1.11.10"

--- a/packages/datepicker/src/lib/DateCalendar.tsx
+++ b/packages/datepicker/src/lib/DateCalendar.tsx
@@ -1,0 +1,25 @@
+import { DateCalendar as MuiDateCalendar, DateCalendarProps as MuiDateCalendarProps } from '@mui/x-date-pickers/DateCalendar';
+import type { Dayjs } from 'dayjs';
+import type {} from '@mui/x-date-pickers/AdapterDayjs';
+
+export type DateCalendarProps = Omit<MuiDateCalendarProps<Dayjs>,
+  | 'components'
+  | 'componentsProps'
+  | 'slots'
+  | 'slotProps'
+  | 'ToolbarComponent'
+  | 'toolbarFormat'
+  | 'toolbarPlaceholder'
+  | 'toolbarTitle'
+  | 'TransitionComponent'
+>;
+
+// just being used for stories atm, if ux finds a use for it we can add it to index.
+export const DateCalendar = (props: DateCalendarProps): JSX.Element => {
+  return (
+    <MuiDateCalendar
+      {...props}
+      dayOfWeekFormatter = {(weekday: Dayjs) => weekday.format('dd')}
+    />
+  );
+};

--- a/packages/datepicker/src/lib/Datepicker.stories.tsx
+++ b/packages/datepicker/src/lib/Datepicker.stories.tsx
@@ -1,14 +1,14 @@
 // Each exported component in the package should have its own stories file
-import type { Meta, StoryObj } from '@storybook/react';
-import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
-import { MonthCalendar } from '@mui/x-date-pickers/MonthCalendar';
-import { YearCalendar } from '@mui/x-date-pickers/YearCalendar';
 import { useState } from 'react';
-import dayjs, { Dayjs } from 'dayjs';
-import { Datepicker, DatepickerProps } from './Datepicker';
+import type { Meta, StoryObj } from '@storybook/react';
 import Grid from '@mui/material/Unstable_Grid2';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
+import { MonthCalendar } from '@mui/x-date-pickers/MonthCalendar';
+import { YearCalendar } from '@mui/x-date-pickers/YearCalendar';
+import dayjs, { Dayjs } from 'dayjs';
+import { Datepicker, DatepickerProps } from './Datepicker';
+import { DateCalendar } from './DateCalendar';
 
 const meta: Meta<typeof Datepicker> = {
   title: 'Form Components/Datepicker/Datepicker',
@@ -42,7 +42,7 @@ export const _Datepicker: StoryObj<typeof Datepicker> = {
   },
 };
 
-export const _PickerViews: StoryObj<typeof Datepicker> = {
+export const _PickerViews: StoryObj<typeof DateCalendar> = {
   render: () => {
     const minDate = dayjs('2020-01-01T00:00:00.000');
     const maxDate = dayjs('2034-01-01T00:00:00.000');
@@ -52,7 +52,7 @@ export const _PickerViews: StoryObj<typeof Datepicker> = {
       <Grid container spacing={3}>
         <Grid xs="auto">
           <Typography variant="h3" component="span">
-            Day View
+            Default View
           </Typography>
           <Paper sx={{ width: 'min-content' }}>
             <DateCalendar value={date} onChange={(newDate) => setDate(newDate)} />

--- a/packages/datepicker/src/lib/Datepicker.tsx
+++ b/packages/datepicker/src/lib/Datepicker.tsx
@@ -1,4 +1,5 @@
 import { TextField, TextFieldProps } from '@availity/mui-textfield';
+import { CalendarDaysIcon } from '@availity/mui-icon';
 import { DatePicker as MuiDatePicker, DatePickerProps as MuiDatePickerProps } from '@mui/x-date-pickers/DatePicker';
 import type { Dayjs } from 'dayjs';
 import type {} from '@mui/x-date-pickers/AdapterDayjs';
@@ -26,6 +27,8 @@ export type DatepickerProps = {
   | 'renderInput'
   | 'rifmFormatter'
   | 'showToolbar'
+  | 'slots'
+  | 'slotProps'
   | 'ToolbarComponent'
   | 'toolbarFormat'
   | 'toolbarPlaceholder'
@@ -36,29 +39,33 @@ export type DatepickerProps = {
 
 const paperProps = { elevation: 8, variant: 'elevation', sx: { marginTop: '4px' } } as const;
 
-const PickerTextField = (params: TextFieldProps) => {
-  if (params.inputProps) {
-    params.inputProps.placeholder = 'MM/DD/YYYY';
-  }
-
-  return <TextField {...params} />;
-};
-
 export const Datepicker = ({ FieldProps, placement = 'bottom-start', ...props }: DatepickerProps): JSX.Element => {
   return (
     <MuiDatePicker
       {...props}
+      dayOfWeekFormatter = {(weekday: Dayjs) => weekday.format('dd')}
       slotProps={{
         desktopPaper: paperProps,
-        mobilePaper: paperProps,
-        textField: FieldProps,
+        mobilePaper: {
+          ...paperProps,
+          'aria-label': FieldProps?.label?.toString() || FieldProps?.inputProps?.['aria-label'] || "Date picker",
+          'aria-labelledby': FieldProps?.inputProps?.['aria-labelledby'] || undefined
+        },
         popper: {
           placement,
+          'aria-label': FieldProps?.label?.toString() || FieldProps?.inputProps?.['aria-label'] || "Date picker",
+          'aria-labelledby': FieldProps?.inputProps?.['aria-labelledby'] || undefined
         },
+        openPickerIcon: {
+          fontSize: 'xsmall'
+        },
+        textField: FieldProps,
       }}
       slots={{
-        textField: PickerTextField,
+        openPickerIcon: CalendarDaysIcon,
+        textField: TextField,
       }}
+
     />
   );
 };

--- a/packages/theme-provider/src/lib/theme-provider.tsx
+++ b/packages/theme-provider/src/lib/theme-provider.tsx
@@ -3,7 +3,8 @@ import { ThemeProvider as MuiThemeProvider, createTheme } from '@mui/material/st
 import type { Theme, ThemeOptions } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { LocalizationProvider } from '@mui/x-date-pickers';
+import { enUS as enUSDate } from '@mui/x-date-pickers/locales';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 
 const lightTheme = createTheme(lightThemeOptions as ThemeOptions);
 const legacyTheme = createTheme(legacyThemeOptions as ThemeOptions);
@@ -13,6 +14,7 @@ export type ThemeProviderProps = {
   /** Availity theme to use */
   theme?: 'lightTheme' | 'legacyBS';
 };
+
 const themes: Record<string, Theme> = {
   lightTheme: lightTheme,
   legacyBS: legacyTheme,
@@ -20,7 +22,10 @@ const themes: Record<string, Theme> = {
 
 export function ThemeProvider({ children, theme = 'lightTheme' }: ThemeProviderProps) {
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs}>
+    <LocalizationProvider
+      dateAdapter={AdapterDayjs}
+      localeText={enUSDate.components.MuiLocalizationProvider.defaultProps.localeText}
+    >
       <MuiThemeProvider theme={themes[theme]}>
         <CssBaseline />
         {children}

--- a/packages/theme/src/lib/legacy-theme.ts
+++ b/packages/theme/src/lib/legacy-theme.ts
@@ -51,8 +51,6 @@ const typographyStyles = (type: string) => ({
   lineHeight: `${tokens[`lineHeights${type}` as keyof typeof tokens]}`,
 });
 
-const dayOfWeekFormatter = (day: string) => day.charAt(0).toUpperCase() + day.charAt(1);
-
 export const legacyTheme = {
   mode: 'light',
   palette: {
@@ -852,13 +850,6 @@ export const legacyTheme = {
         },
       },
     },
-    // v5 datepicker, move to MuiDatePicker in v6+
-    MuiCalendarPicker: {
-      defaultProps: {
-        disableHighlightToday: true,
-        dayOfWeekFormatter: dayOfWeekFormatter,
-      },
-    },
     MuiCard: {
       defaultProps: {
         variant: 'outlined',
@@ -1084,31 +1075,16 @@ export const legacyTheme = {
         },
       },
     },
-    MuiDialogTitle: {
-      styleOverrides: {
-        root: {
-          backgroundColor: tokens.colorGrey100,
-          marginBottom: '24px',
-        },
+    MuiDatePicker: {
+      defaultProps: {
+        disableHighlightToday: true,
       },
     },
-    MuiDialogContent: {
+    MuiDayCalendar: {
       styleOverrides: {
         root: {
-          padding: '24px',
+
         },
-      },
-    },
-    MuiDialogActions: {
-      styleOverrides: {
-        root: {
-          backgroundColor: tokens.colorGrey100,
-        },
-      },
-    },
-    // v5 Datepicker, MuiDayCalendar in v6
-    MuiDayPicker: {
-      styleOverrides: {
         weekDayLabel: {
           fontSize: '.75rem',
           width: '39px',
@@ -1125,6 +1101,30 @@ export const legacyTheme = {
           '&:last-of-type': {
             marginBottom: '1px',
           },
+
+        }
+      }
+
+    },
+    MuiDialogActions: {
+      styleOverrides: {
+        root: {
+          backgroundColor: tokens.colorGrey100,
+        },
+      },
+    },
+    MuiDialogContent: {
+      styleOverrides: {
+        root: {
+          padding: '24px',
+        },
+      },
+    },
+    MuiDialogTitle: {
+      styleOverrides: {
+        root: {
+          backgroundColor: tokens.colorGrey100,
+          marginBottom: '24px',
         },
       },
     },
@@ -1721,7 +1721,7 @@ export const legacyTheme = {
           margin: '0px 0px 0px -1px',
           padding: '0px',
           borderRadius: 0,
-          border: `1px solid ${tokens.colorGrey100}`,
+          border: `1px solid ${tokens.colorGrey200}`,
           fontSize: '1.5rem',
           '&.Mui-focused, &:focus': {
             outline: `none`,
@@ -1781,11 +1781,22 @@ export const legacyTheme = {
           },
         },
         today: {
-          border: `1px solid ${tokens.colorGrey100}`,
+          '&:not(.Mui-selected), &:not(.Mui-focused)': {
+            border: `1px solid ${tokens.colorGrey100}`
+          }
         },
       },
     },
-    // v5 DatePicker, pass paper props to MuiDatePicker in v6+
+    MuiPickersMonth: {
+      styleOverrides: {
+        monthButton: {
+          borderRadius: '4px',
+          ':hover, :focus:not(.Mui-selected)': {
+            backgroundColor: tokens.colorGrey100,
+          },
+        }
+      }
+    },
     MuiPickersPopper: {
       styleOverrides: {
         paper: {
@@ -1793,6 +1804,16 @@ export const legacyTheme = {
           border: `1px solid ${tokens.borderDecorative}`,
         },
       },
+    },
+    MuiPickersYear: {
+      styleOverrides: {
+        yearButton: {
+          borderRadius: '4px',
+          ':hover, :focus:not(.Mui-selected)': {
+            backgroundColor: tokens.colorGrey100,
+          },
+        }
+      }
     },
     MuiPopover: {
       defaultProps: {
@@ -2377,28 +2398,6 @@ export const legacyTheme = {
           body2: 'p',
           inherit: 'p',
           agreement: 'div'
-        },
-      },
-    },
-    // v5 datepicker
-    PrivatePickersMonth: {
-      styleOverrides: {
-        root: {
-          borderRadius: '4px',
-          ':hover, :focus:not(.Mui-selected)': {
-            backgroundColor: tokens.colorGrey100,
-          },
-        },
-      },
-    },
-    PrivatePickersYear: {
-      styleOverrides: {
-        root: {},
-        button: {
-          borderRadius: '4px',
-          ':hover, :focus:not(.Mui-selected)': {
-            backgroundColor: tokens.colorGrey100,
-          },
         },
       },
     },

--- a/packages/theme/src/lib/light-theme.ts
+++ b/packages/theme/src/lib/light-theme.ts
@@ -867,16 +867,6 @@ export const lightTheme = {
         },
       },
     },
-    MuiCalendarPicker: {
-      styleOverrides: {
-        root: {
-          width: '310px',
-          '.MuiIconButton-root': {
-            border: '0',
-          },
-        },
-      },
-    },
     MuiCard: {
       defaultProps: {
         variant: 'elevation',
@@ -995,7 +985,24 @@ export const lightTheme = {
         },
       },
     },
-    MuiDayPicker: {
+    MuiDateCalendar: {
+      styleOverrides: {
+        root: {
+          width: '310px'
+        }
+      }
+    },
+    MuiDatePicker: {
+      styleOverrides: {
+        root: {
+          width: '310px',
+          '.MuiIconButton-root': {
+            border: '0',
+          },
+        },
+      },
+    },
+    MuiDayCalendar: {
       styleOverrides: {
         header: {
           paddingBottom: '12px',
@@ -1215,7 +1222,7 @@ export const lightTheme = {
               },
               '.MuiIconButton-root': {
                 border: '0',
-                padding: '8px',
+                // padding: '8px',
                 color: tokens.colorGrey400,
               },
               '.MuiChip-label': {

--- a/yarn.lock
+++ b/yarn.lock
@@ -426,6 +426,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@availity/mui-datepicker@workspace:packages/datepicker"
   dependencies:
+    "@availity/mui-icon": "workspace:*"
     "@availity/mui-textfield": "workspace:*"
     "@mui/material": ^5.15.15
     "@mui/x-date-pickers": ^7.2.0


### PR DESCRIPTION
- there is default aria-name for dialog, but if aria-labelledby is passed instead of label it takes precedence over name :)
- placeholder replaced with locale text at the theme-provider (localizationprovider) level.
- legacy day of week formatter types changed, moved out of theme and into component. Peeked at the datepicker specs and it looks like the new theme is also going with the two letter day abbrs like the legacy theme.
- swapped out the picker icon to match specs since I was already in there.
- did not look for any other light theme updates besides the x-date-picker update changes.