### PR TITLE
feat: set the body background color

### DIFF
--- a/packages/theme/src/lib/light-theme.ts
+++ b/packages/theme/src/lib/light-theme.ts
@@ -991,6 +991,13 @@ export const lightTheme = {
         },
       },
     },
+    MuiCssBaseline: {
+      styleOverrides: {
+        body: {
+          backgroundColor: tokens.colorBackgroundCanvas,
+        }
+      }
+    },
     MuiDateCalendar: {
       styleOverrides: {
         root: {


### PR DESCRIPTION
Currently everyone would need to set the body background color on their own. This means everyone has to realize this needs to be done and determine how to do this on their own. Most developers using workflow and coming from uikit will probably opt to [updating the scss](https://github.com/Availity/availity-starter-react/blob/a652adea39425505f4a4ac5b940d53e8151bc620/project/app/index.scss#L7-L9), but you can't (easily) pull the token values into scss so they will most likely hardcode it. To avoid hardcoding this commonly used body background color, it should just default to it.