### PR TITLE
fix(mui-page-header): pass key in map

### DIFF
--- a/packages/page-header/src/lib/PageHeader.tsx
+++ b/packages/page-header/src/lib/PageHeader.tsx
@@ -126,8 +126,8 @@ export const PageHeader = ({
         <Grid container width="auto">
           {buttons &&
             buttons.length > 0 &&
-            buttons?.map((buttonProps) => (
-              <Grid marginLeft={2} height="100%">
+            buttons?.map(({ key, ...buttonProps }) => (
+              <Grid key={key} marginLeft={2} height="100%">
                 <Button {...buttonProps} size="large" color="secondary" />
               </Grid>
             ))}


### PR DESCRIPTION
>Warning: Each child in a list should have a unique "key" prop.
Check the render method of `PageHeader`. See https://reactjs.org/link/warning-keys for more information.