### PR TITLE
fix(mui-controlled-form): support nested form properties

### DIFF
--- a/packages/controlled-form/src/lib/AsyncAutocomplete.tsx
+++ b/packages/controlled-form/src/lib/AsyncAutocomplete.tsx
@@ -35,11 +35,8 @@ export const ControlledAsyncAutocomplete = <
   FieldProps,
   ...rest
 }: ControlledAsyncAutocompleteProps<Option, Multiple, DisableClearable, FreeSolo, ChipComponent>) => {
-  const {
-    control,
-    formState: { errors },
-  } = useFormContext();
-  const errorMessage = errors[name]?.message;
+  const { control, getFieldState } = useFormContext();
+  const errorMessage = getFieldState(name).error?.message;
   return (
     <Controller
       name={name}

--- a/packages/controlled-form/src/lib/Autocomplete.tsx
+++ b/packages/controlled-form/src/lib/Autocomplete.tsx
@@ -39,11 +39,8 @@ export const ControlledAutocomplete = <
   value,
   ...rest
 }: ControlledAutocompleteProps<T, Multiple, DisableClearable, FreeSolo, ChipComponent>) => {
-  const {
-    control,
-    formState: { errors },
-  } = useFormContext();
-  const errorMessage = errors[name]?.message;
+  const { control, getFieldState } = useFormContext();
+  const errorMessage = getFieldState(name).error?.message;
   return (
     <Controller
       control={control}

--- a/packages/controlled-form/src/lib/CodesAutocomplete.tsx
+++ b/packages/controlled-form/src/lib/CodesAutocomplete.tsx
@@ -21,11 +21,8 @@ export const ControlledCodesAutocomplete = ({
   FieldProps,
   ...rest
 }: ControlledCodesAutocompleteProps) => {
-  const {
-    control,
-    formState: { errors },
-  } = useFormContext();
-  const errorMessage = errors[name]?.message;
+  const { control, getFieldState } = useFormContext();
+  const errorMessage = getFieldState(name).error?.message;
   return (
     <Controller
       name={name}

--- a/packages/controlled-form/src/lib/Input.tsx
+++ b/packages/controlled-form/src/lib/Input.tsx
@@ -24,14 +24,11 @@ export const ControlledInput = ({
   deps,
   ...rest
 }: ControlledInputProps) => {
-  const {
-    register,
-    formState: { errors },
-  } = useFormContext();
+  const { register, getFieldState } = useFormContext();
   return (
     <Input
       {...rest}
-      error={!!errors[name]}
+      error={!!getFieldState(name).error}
       required={!!required}
       {...register(name, {
         required,

--- a/packages/controlled-form/src/lib/OrganizationAutocomplete.tsx
+++ b/packages/controlled-form/src/lib/OrganizationAutocomplete.tsx
@@ -22,11 +22,8 @@ export const ControlledOrganizationAutocomplete = ({
   FieldProps,
   ...rest
 }: ControlledOrgAutocompleteProps) => {
-  const {
-    control,
-    formState: { errors },
-  } = useFormContext();
-  const errorMessage = errors[name]?.message;
+  const { control, getFieldState } = useFormContext();
+  const errorMessage = getFieldState(name).error?.message;
   return (
     <Controller
       name={name}

--- a/packages/controlled-form/src/lib/ProviderAutocomplete.tsx
+++ b/packages/controlled-form/src/lib/ProviderAutocomplete.tsx
@@ -23,11 +23,8 @@ export const ControlledProviderAutocomplete = ({
   FieldProps,
   ...rest
 }: ControlledProviderAutocompleteProps) => {
-  const {
-    control,
-    formState: { errors },
-  } = useFormContext();
-  const errorMessage = errors[name]?.message;
+  const { control, getFieldState } = useFormContext();
+  const errorMessage = getFieldState(name).error?.message;
   return (
     <Controller
       name={name}

--- a/packages/controlled-form/src/lib/RadioGroup.tsx
+++ b/packages/controlled-form/src/lib/RadioGroup.tsx
@@ -34,11 +34,8 @@ export const ControlledRadioGroup = ({
   value,
   ...rest
 }: ControlledRadioGroupProps) => {
-  const {
-    control,
-    formState: { errors },
-  } = useFormContext();
-  const errorMessage = errors[name]?.message;
+  const { control, getFieldState } = useFormContext();
+  const errorMessage = getFieldState(name).error?.message;
   return (
     <Controller
       control={control}

--- a/packages/controlled-form/src/lib/Select.tsx
+++ b/packages/controlled-form/src/lib/Select.tsx
@@ -24,15 +24,12 @@ export const ControlledSelect = ({
   deps,
   ...rest
 }: ControlledSelectProps) => {
-  const {
-    register,
-    formState: { errors },
-  } = useFormContext();
+  const { register, getFieldState } = useFormContext();
 
   return (
     <Select
       {...rest}
-      error={!!errors[name]}
+      error={!!getFieldState(name).error}
       required={!!required}
       {...register(name, {
         required,

--- a/packages/controlled-form/src/lib/TextField.tsx
+++ b/packages/controlled-form/src/lib/TextField.tsx
@@ -24,12 +24,9 @@ export const ControlledTextField = ({
   deps,
   ...rest
 }: ControlledTextFieldProps) => {
-  const {
-    register,
-    formState: { errors },
-  } = useFormContext();
+  const { register, getFieldState } = useFormContext();
 
-  const errorMessage = errors[name]?.message;
+  const errorMessage = getFieldState(name).error?.message;
 
   return (
     <TextField
@@ -50,7 +47,7 @@ export const ControlledTextField = ({
         shouldUnregister,
         deps,
       })}
-      error={!!errors[name]}
+      error={!!getFieldState(name).error}
       helperText={
         errorMessage && typeof errorMessage === 'string' ? (
           <>


### PR DESCRIPTION
Currently, a nested property like `address.state`'s error styles will not appear. The errors object returned by RHF matches the structure of the underlying form, allowing nesting of objects and arrays accessed by index. Previously direct string access `errors[name]` resulted in something like `errors['address.state']` which would result in `undefined`. This PR changes it to use the `getFieldState` method provided by RHF which uses a `get` function similar to lodash's that works with dot and index notation in a string to traverse an object.