### PR TITLE
fix(mui-controlled-form): forward required from controlled text field to text field

### DIFF
--- a/packages/controlled-form/src/lib/TextField.tsx
+++ b/packages/controlled-form/src/lib/TextField.tsx
@@ -34,6 +34,7 @@ export const ControlledTextField = ({
   return (
     <TextField
       {...rest}
+      required={!!required}
       {...register(name, {
         required,
         maxLength,


### PR DESCRIPTION
Currently, the red asterisk does not appear when `ControlledTextField` has the `required` prop. This change forwards the `required` prop (converting it to a boolean) to the underlying `TextField` so that it displays the red asterisk. 