### PR TITLE
fix(mui-controlled-form): support required prop object

### DIFF
--- a/packages/controlled-form/src/lib/AsyncAutocomplete.tsx
+++ b/packages/controlled-form/src/lib/AsyncAutocomplete.tsx
@@ -62,6 +62,7 @@ export const ControlledAsyncAutocomplete = <
           {...rest}
           FieldProps={{
             ...FieldProps,
+            required: typeof required === 'object' ? required.value : !!required,
             error: !!errorMessage,
             helperText:
               errorMessage && typeof errorMessage === 'string' ? (

--- a/packages/controlled-form/src/lib/Autocomplete.tsx
+++ b/packages/controlled-form/src/lib/Autocomplete.tsx
@@ -66,6 +66,7 @@ export const ControlledAutocomplete = <
           {...rest}
           FieldProps={{
             ...FieldProps,
+            required: typeof required === 'object' ? required.value : !!required,
             error: !!errorMessage,
             helperText:
               errorMessage && typeof errorMessage === 'string' ? (

--- a/packages/controlled-form/src/lib/CodesAutocomplete.tsx
+++ b/packages/controlled-form/src/lib/CodesAutocomplete.tsx
@@ -46,6 +46,7 @@ export const ControlledCodesAutocomplete = ({
           {...rest}
           FieldProps={{
             ...FieldProps,
+            required: typeof required === 'object' ? required.value : !!required,
             error: !!errorMessage,
             helperText:
               errorMessage && typeof errorMessage === 'string' ? (

--- a/packages/controlled-form/src/lib/Datepicker.tsx
+++ b/packages/controlled-form/src/lib/Datepicker.tsx
@@ -20,6 +20,7 @@ export const ControlledDatepicker = ({
   shouldUnregister,
   validate,
   value,
+  FieldProps,
   ...rest
 }: ControlledDatepickerProps) => {
   const { control } = useFormContext();
@@ -43,7 +44,27 @@ export const ControlledDatepicker = ({
         value,
       }}
       shouldUnregister={shouldUnregister}
-      render={({ field: { onChange, value } }) => <Datepicker {...rest} onChange={onChange} value={value || null} />}
+      render={({ field: { onChange, value }, fieldState: { error } }) => (
+        <Datepicker
+          {...rest}
+          FieldProps={{
+            ...FieldProps,
+            required: typeof required === 'object' ? required.value : !!required,
+            error: !!error,
+            helperText: error?.message ? (
+              <>
+                {error?.message}
+                <br />
+                {FieldProps?.helperText}
+              </>
+            ) : (
+              FieldProps?.helperText
+            ),
+          }}
+          onChange={onChange}
+          value={value || null}
+        />
+      )}
     />
   );
 };

--- a/packages/controlled-form/src/lib/Input.tsx
+++ b/packages/controlled-form/src/lib/Input.tsx
@@ -29,7 +29,7 @@ export const ControlledInput = ({
     <Input
       {...rest}
       error={!!getFieldState(name).error}
-      required={!!required}
+      required={typeof required === 'object' ? required.value : !!required}
       {...register(name, {
         required,
         maxLength,

--- a/packages/controlled-form/src/lib/OrganizationAutocomplete.tsx
+++ b/packages/controlled-form/src/lib/OrganizationAutocomplete.tsx
@@ -45,6 +45,7 @@ export const ControlledOrganizationAutocomplete = ({
           {...rest}
           FieldProps={{
             ...FieldProps,
+            required: typeof required === 'object' ? required.value : !!required,
             error: !!errorMessage,
             helperText:
               errorMessage && typeof errorMessage === 'string' ? (

--- a/packages/controlled-form/src/lib/ProviderAutocomplete.tsx
+++ b/packages/controlled-form/src/lib/ProviderAutocomplete.tsx
@@ -50,6 +50,7 @@ export const ControlledProviderAutocomplete = ({
           {...rest}
           FieldProps={{
             ...FieldProps,
+            required: typeof required === 'object' ? required.value : !!required,
             error: !!errorMessage,
             helperText:
               errorMessage && typeof errorMessage === 'string' ? (

--- a/packages/controlled-form/src/lib/RadioGroup.tsx
+++ b/packages/controlled-form/src/lib/RadioGroup.tsx
@@ -45,7 +45,7 @@ export const ControlledRadioGroup = ({
       shouldUnregister={shouldUnregister}
       render={({ field }) => (
         <FormControl error={!!errorMessage}>
-          <FormLabel>{label}</FormLabel>
+          <FormLabel required={typeof required === 'object' ? required.value : !!required}>{label}</FormLabel>
           <RadioGroup {...field} {...rest} />
           <FormHelperText>
             {errorMessage && typeof errorMessage === 'string' ? (

--- a/packages/controlled-form/src/lib/Select.tsx
+++ b/packages/controlled-form/src/lib/Select.tsx
@@ -30,7 +30,7 @@ export const ControlledSelect = ({
     <Select
       {...rest}
       error={!!getFieldState(name).error}
-      required={!!required}
+      required={typeof required === 'object' ? required.value : !!required}
       {...register(name, {
         required,
         maxLength,

--- a/packages/controlled-form/src/lib/TextField.tsx
+++ b/packages/controlled-form/src/lib/TextField.tsx
@@ -31,7 +31,7 @@ export const ControlledTextField = ({
   return (
     <TextField
       {...rest}
-      required={!!required}
+      required={typeof required === 'object' ? required.value : !!required}
       {...register(name, {
         required,
         maxLength,


### PR DESCRIPTION
RHF's `required` prop can be a boolean, string, or object. In the case of object, the validation message and value (if the required validation enabled/disabled) are both present and he validation itself might be disabled (passing `false` to `value`.) While this is probably an edge-case, passing the previous code did not handle it and would set `required` to `true` when `{value: false}` was passed in resulting in the asterisk showing even though it is not required.