### PR TITLE
refactor(mui-controlled-form): replace RHF's register with RHF's Controller

### DIFF
--- a/packages/controlled-form/src/lib/AsyncAutocomplete.tsx
+++ b/packages/controlled-form/src/lib/AsyncAutocomplete.tsx
@@ -1,5 +1,5 @@
 import { AsyncAutocomplete, AsyncAutocompleteProps } from '@availity/mui-autocomplete';
-import { useFormContext, RegisterOptions, FieldValues, Controller, ControllerProps } from 'react-hook-form';
+import { RegisterOptions, FieldValues, Controller, ControllerProps } from 'react-hook-form';
 import { ChipTypeMap } from '@mui/material/Chip';
 
 export type ControlledAsyncAutocompleteProps<
@@ -35,12 +35,9 @@ export const ControlledAsyncAutocomplete = <
   FieldProps,
   ...rest
 }: ControlledAsyncAutocompleteProps<Option, Multiple, DisableClearable, FreeSolo, ChipComponent>) => {
-  const { control, getFieldState } = useFormContext();
-  const errorMessage = getFieldState(name).error?.message;
   return (
     <Controller
       name={name}
-      control={control}
       defaultValue={rest.defaultValue}
       rules={{
         deps,
@@ -57,23 +54,22 @@ export const ControlledAsyncAutocomplete = <
         value,
       }}
       shouldUnregister={shouldUnregister}
-      render={({ field: { onChange, value, onBlur } }) => (
+      render={({ field: { onChange, value, onBlur }, fieldState: { error } }) => (
         <AsyncAutocomplete
           {...rest}
           FieldProps={{
             ...FieldProps,
             required: typeof required === 'object' ? required.value : !!required,
-            error: !!errorMessage,
-            helperText:
-              errorMessage && typeof errorMessage === 'string' ? (
-                <>
-                  {errorMessage}
-                  <br />
-                  {FieldProps?.helperText}
-                </>
-              ) : (
-                FieldProps?.helperText
-              ),
+            error: !!error,
+            helperText: error?.message ? (
+              <>
+                {error.message}
+                <br />
+                {FieldProps?.helperText}
+              </>
+            ) : (
+              FieldProps?.helperText
+            ),
           }}
           onChange={(event, value, reason) => {
             if (reason === 'clear') {

--- a/packages/controlled-form/src/lib/Autocomplete.tsx
+++ b/packages/controlled-form/src/lib/Autocomplete.tsx
@@ -1,5 +1,5 @@
 import { Autocomplete, AutocompleteProps } from '@availity/mui-autocomplete';
-import { useFormContext, RegisterOptions, FieldValues, Controller, ControllerProps } from 'react-hook-form';
+import { RegisterOptions, FieldValues, Controller, ControllerProps } from 'react-hook-form';
 import { ChipTypeMap } from '@mui/material/Chip';
 
 export type ControlledAutocompleteProps<
@@ -39,11 +39,8 @@ export const ControlledAutocomplete = <
   value,
   ...rest
 }: ControlledAutocompleteProps<T, Multiple, DisableClearable, FreeSolo, ChipComponent>) => {
-  const { control, getFieldState } = useFormContext();
-  const errorMessage = getFieldState(name).error?.message;
   return (
     <Controller
-      control={control}
       name={name}
       defaultValue={defaultValue}
       rules={{
@@ -61,23 +58,22 @@ export const ControlledAutocomplete = <
         value,
       }}
       shouldUnregister={shouldUnregister}
-      render={({ field: { onChange, value, onBlur } }) => (
+      render={({ field: { onChange, value, onBlur }, fieldState: { error } }) => (
         <Autocomplete
           {...rest}
           FieldProps={{
             ...FieldProps,
             required: typeof required === 'object' ? required.value : !!required,
-            error: !!errorMessage,
-            helperText:
-              errorMessage && typeof errorMessage === 'string' ? (
-                <>
-                  {errorMessage}
-                  <br />
-                  {FieldProps?.helperText}
-                </>
-              ) : (
-                FieldProps?.helperText
-              ),
+            error: !!error,
+            helperText: error?.message ? (
+              <>
+                {error.message}
+                <br />
+                {FieldProps?.helperText}
+              </>
+            ) : (
+              FieldProps?.helperText
+            ),
           }}
           onChange={(event, value, reason) => {
             if (reason === 'clear') {

--- a/packages/controlled-form/src/lib/Checkbox.stories.tsx
+++ b/packages/controlled-form/src/lib/Checkbox.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { ControlledCheckbox } from './Checkbox';
+import { ControlledCheckbox, ControlledCheckboxProps } from './Checkbox';
 import { ControlledForm } from './ControlledForm';
 import { Button } from '@availity/mui-button';
 import { useFormContext } from 'react-hook-form';
@@ -17,7 +17,7 @@ const meta: Meta<typeof ControlledCheckbox> = {
 export default meta;
 
 export const _ControlledCheckbox: StoryObj<typeof ControlledCheckbox> = {
-  render: () => {
+  render: (args: ControlledCheckboxProps) => {
     const SubmittedValues = () => {
       const {
         getValues,
@@ -39,19 +39,24 @@ export const _ControlledCheckbox: StoryObj<typeof ControlledCheckbox> = {
       } = useFormContext();
       return (
         <Grid container direction="row" justifyContent="space-between" marginTop={1}>
-          <Button disabled={!isSubmitSuccessful} children="Reset" color="secondary" onClick={() => reset()} />
+          <Button
+            disabled={!isSubmitSuccessful}
+            children="Reset"
+            color="secondary"
+            onClick={() => reset({ [args.name]: false })}
+          />
           <Button type="submit" disabled={isSubmitSuccessful} children="Submit" />
         </Grid>
       );
     };
     return (
-      <ControlledForm onSubmit={(data) => data} values={{ controlledCheckbox: undefined }}>
+      <ControlledForm onSubmit={(data) => data} values={{ [args.name]: false }} noValidate>
         <FormControl>
           <FormLabel id="radio-group" component="div">
             Radio Group
           </FormLabel>
           <FormGroup>
-            <FormControlLabel label="Option 1" control={<ControlledCheckbox name="Option 1" />} />
+            <FormControlLabel label="Option 1" control={<ControlledCheckbox {...args} />} />
             <FormControlLabel label="Option 2" control={<ControlledCheckbox name="Option 2" />} />
             <FormControlLabel label="Option 3" control={<ControlledCheckbox name="Option 3" />} />
           </FormGroup>

--- a/packages/controlled-form/src/lib/Checkbox.tsx
+++ b/packages/controlled-form/src/lib/Checkbox.tsx
@@ -1,37 +1,49 @@
 import { Checkbox, CheckboxProps } from '@availity/mui-checkbox';
-import { useFormContext, RegisterOptions, FieldValues } from 'react-hook-form';
+import { RegisterOptions, FieldValues, Controller, ControllerProps } from 'react-hook-form';
 
-export type ControlledCheckboxProps = CheckboxProps & {
-  name: string;
-} & Omit<
+export type ControlledCheckboxProps = CheckboxProps &
+  Omit<
     RegisterOptions<FieldValues, string>,
-    'required' | 'max' | 'maxLength' | 'min' | 'minLength' | 'pattern' | 'validate'
-  >;
+    | 'required'
+    | 'disabled'
+    | 'valueAsNumber'
+    | 'valueAsDate'
+    | 'setValueAs'
+    | 'max'
+    | 'maxLength'
+    | 'min'
+    | 'minLength'
+    | 'pattern'
+  > &
+  Pick<ControllerProps, 'defaultValue' | 'shouldUnregister' | 'name'>;
 
 export const ControlledCheckbox = ({
   name,
-  setValueAs,
   disabled,
   onChange,
   onBlur,
   value,
+  defaultValue = false,
   shouldUnregister,
   deps,
   ...rest
 }: ControlledCheckboxProps) => {
-  const { register } = useFormContext();
   return (
-    <Checkbox
-      {...rest}
-      {...register(name, {
-        setValueAs,
-        disabled,
+    <Controller
+      name={name}
+      defaultValue={defaultValue}
+      disabled={disabled}
+      rules={{
         onChange,
         onBlur,
         value,
         shouldUnregister,
         deps,
-      })}
+      }}
+      shouldUnregister={shouldUnregister}
+      render={({ field }) => (
+        <Checkbox {...rest} {...field} checked={field.value} onChange={(e) => field.onChange(e.target.checked)} />
+      )}
     />
   );
 };

--- a/packages/controlled-form/src/lib/CodesAutocomplete.tsx
+++ b/packages/controlled-form/src/lib/CodesAutocomplete.tsx
@@ -1,5 +1,5 @@
 import { CodesAutocomplete, CodesAutocompleteProps } from '@availity/mui-autocomplete';
-import { useFormContext, Controller, RegisterOptions, ControllerProps, FieldValues } from 'react-hook-form';
+import { Controller, RegisterOptions, ControllerProps, FieldValues } from 'react-hook-form';
 
 export type ControlledCodesAutocompleteProps = Omit<CodesAutocompleteProps, 'name'> &
   Omit<RegisterOptions<FieldValues, string>, 'disabled' | 'valueAsNumber' | 'valueAsDate' | 'setValueAs'> &
@@ -21,12 +21,9 @@ export const ControlledCodesAutocomplete = ({
   FieldProps,
   ...rest
 }: ControlledCodesAutocompleteProps) => {
-  const { control, getFieldState } = useFormContext();
-  const errorMessage = getFieldState(name).error?.message;
   return (
     <Controller
       name={name}
-      control={control}
       defaultValue={defaultValue}
       rules={{
         deps,
@@ -41,23 +38,22 @@ export const ControlledCodesAutocomplete = ({
         value,
       }}
       shouldUnregister={shouldUnregister}
-      render={({ field: { onChange, value, onBlur } }) => (
+      render={({ field: { onChange, value, onBlur }, fieldState: { error } }) => (
         <CodesAutocomplete
           {...rest}
           FieldProps={{
             ...FieldProps,
             required: typeof required === 'object' ? required.value : !!required,
-            error: !!errorMessage,
-            helperText:
-              errorMessage && typeof errorMessage === 'string' ? (
-                <>
-                  {errorMessage}
-                  <br />
-                  {FieldProps?.helperText}
-                </>
-              ) : (
-                FieldProps?.helperText
-              ),
+            error: !!error,
+            helperText: error?.message ? (
+              <>
+                {error.message}
+                <br />
+                {FieldProps?.helperText}
+              </>
+            ) : (
+              FieldProps?.helperText
+            ),
           }}
           onChange={(event, value, reason) => {
             if (reason === 'clear') {

--- a/packages/controlled-form/src/lib/Datepicker.tsx
+++ b/packages/controlled-form/src/lib/Datepicker.tsx
@@ -1,5 +1,5 @@
 import { Datepicker, DatepickerProps } from '@availity/mui-datepicker';
-import { useFormContext, RegisterOptions, FieldValues, Controller, ControllerProps } from 'react-hook-form';
+import { RegisterOptions, FieldValues, Controller, ControllerProps } from 'react-hook-form';
 
 export type ControlledDatepickerProps = DatepickerProps &
   Omit<RegisterOptions<FieldValues, string>, 'disabled' | 'valueAsNumber' | 'valueAsDate' | 'setValueAs'> &
@@ -23,11 +23,9 @@ export const ControlledDatepicker = ({
   FieldProps,
   ...rest
 }: ControlledDatepickerProps) => {
-  const { control } = useFormContext();
   return (
     <Controller
       name={name}
-      control={control}
       defaultValue={defaultValue}
       rules={{
         deps,

--- a/packages/controlled-form/src/lib/Input.stories.tsx
+++ b/packages/controlled-form/src/lib/Input.stories.tsx
@@ -38,13 +38,18 @@ export const _ControlledInput: StoryObj<typeof ControlledInput> = {
       } = useFormContext();
       return (
         <Grid container direction="row" justifyContent="space-between" marginTop={1}>
-          <Button disabled={!isSubmitSuccessful} children="Reset" color="secondary" onClick={() => reset()} />
+          <Button
+            disabled={!isSubmitSuccessful}
+            children="Reset"
+            color="secondary"
+            onClick={() => reset({ [args.name]: '' })}
+          />
           <Button type="submit" disabled={isSubmitSuccessful} children="Submit" />
         </Grid>
       );
     };
     return (
-      <ControlledForm values={{ controlledInput: undefined }} onSubmit={(data) => data}>
+      <ControlledForm values={{ [args.name]: '' }} onSubmit={(data) => data}>
         <ControlledInput {...args} />
         <Actions />
         <SubmittedValues />

--- a/packages/controlled-form/src/lib/Input.tsx
+++ b/packages/controlled-form/src/lib/Input.tsx
@@ -1,10 +1,9 @@
 import { Input, InputProps } from '@availity/mui-form-utils';
-import { useFormContext, RegisterOptions, FieldValues } from 'react-hook-form';
+import { RegisterOptions, FieldValues, Controller, ControllerProps } from 'react-hook-form';
 
-export type ControlledInputProps = Omit<InputProps, 'error' | 'name' | 'required'> & { name: string } & RegisterOptions<
-    FieldValues,
-    string
-  >;
+export type ControlledInputProps = Omit<InputProps, 'error' | 'name' | 'required'> &
+  Omit<RegisterOptions<FieldValues, string>, 'disabled' | 'valueAsNumber' | 'valueAsDate' | 'setValueAs'> &
+  Pick<ControllerProps, 'defaultValue' | 'shouldUnregister' | 'name'>;
 
 export const ControlledInput = ({
   name,
@@ -15,7 +14,7 @@ export const ControlledInput = ({
   min,
   pattern,
   validate,
-  setValueAs,
+  defaultValue,
   disabled,
   onChange,
   onBlur,
@@ -24,13 +23,12 @@ export const ControlledInput = ({
   deps,
   ...rest
 }: ControlledInputProps) => {
-  const { register, getFieldState } = useFormContext();
   return (
-    <Input
-      {...rest}
-      error={!!getFieldState(name).error}
-      required={typeof required === 'object' ? required.value : !!required}
-      {...register(name, {
+    <Controller
+      name={name}
+      defaultValue={defaultValue}
+      disabled={disabled}
+      rules={{
         required,
         maxLength,
         minLength,
@@ -38,14 +36,21 @@ export const ControlledInput = ({
         min,
         pattern,
         validate,
-        setValueAs,
-        disabled,
         onChange,
         onBlur,
         value,
         shouldUnregister,
         deps,
-      })}
+      }}
+      shouldUnregister={shouldUnregister}
+      render={({ field, fieldState: { error } }) => (
+        <Input
+          {...rest}
+          {...field}
+          error={!!error}
+          required={typeof required === 'object' ? required.value : !!required}
+        />
+      )}
     />
   );
 };

--- a/packages/controlled-form/src/lib/OrganizationAutocomplete.tsx
+++ b/packages/controlled-form/src/lib/OrganizationAutocomplete.tsx
@@ -1,5 +1,5 @@
 import { OrganizationAutocomplete, OrgAutocompleteProps } from '@availity/mui-autocomplete';
-import { useFormContext, Controller, RegisterOptions, FieldValues, ControllerProps } from 'react-hook-form';
+import { Controller, RegisterOptions, FieldValues, ControllerProps } from 'react-hook-form';
 
 export type ControlledOrgAutocompleteProps = Omit<OrgAutocompleteProps, 'name'> &
   Omit<
@@ -22,12 +22,9 @@ export const ControlledOrganizationAutocomplete = ({
   FieldProps,
   ...rest
 }: ControlledOrgAutocompleteProps) => {
-  const { control, getFieldState } = useFormContext();
-  const errorMessage = getFieldState(name).error?.message;
   return (
     <Controller
       name={name}
-      control={control}
       defaultValue={defaultValue}
       rules={{
         deps,
@@ -40,23 +37,22 @@ export const ControlledOrganizationAutocomplete = ({
         value,
       }}
       shouldUnregister={shouldUnregister}
-      render={({ field: { onChange, value, onBlur } }) => (
+      render={({ field: { onChange, value, onBlur }, fieldState: { error } }) => (
         <OrganizationAutocomplete
           {...rest}
           FieldProps={{
             ...FieldProps,
             required: typeof required === 'object' ? required.value : !!required,
-            error: !!errorMessage,
-            helperText:
-              errorMessage && typeof errorMessage === 'string' ? (
-                <>
-                  {errorMessage}
-                  <br />
-                  {FieldProps?.helperText}
-                </>
-              ) : (
-                FieldProps?.helperText
-              ),
+            error: !!error,
+            helperText: error?.message ? (
+              <>
+                {error.message}
+                <br />
+                {FieldProps?.helperText}
+              </>
+            ) : (
+              FieldProps?.helperText
+            ),
           }}
           onChange={(event, value, reason) => {
             if (reason === 'clear') {

--- a/packages/controlled-form/src/lib/ProviderAutocomplete.tsx
+++ b/packages/controlled-form/src/lib/ProviderAutocomplete.tsx
@@ -1,5 +1,5 @@
 import { ProviderAutocomplete, ProviderAutocompleteProps } from '@availity/mui-autocomplete';
-import { useFormContext, Controller, RegisterOptions, FieldValues, ControllerProps } from 'react-hook-form';
+import { Controller, RegisterOptions, FieldValues, ControllerProps } from 'react-hook-form';
 
 export type ControlledProviderAutocompleteProps = Omit<ProviderAutocompleteProps, 'name'> &
   Omit<RegisterOptions<FieldValues, string>, 'disabled' | 'valueAsNumber' | 'valueAsDate' | 'setValueAs'> &
@@ -23,12 +23,9 @@ export const ControlledProviderAutocomplete = ({
   FieldProps,
   ...rest
 }: ControlledProviderAutocompleteProps) => {
-  const { control, getFieldState } = useFormContext();
-  const errorMessage = getFieldState(name).error?.message;
   return (
     <Controller
       name={name}
-      control={control}
       defaultValue={defaultValue}
       rules={{
         deps,
@@ -45,23 +42,22 @@ export const ControlledProviderAutocomplete = ({
         value,
       }}
       shouldUnregister={shouldUnregister}
-      render={({ field: { onChange, value, onBlur } }) => (
+      render={({ field: { onChange, value, onBlur }, fieldState: { error } }) => (
         <ProviderAutocomplete
           {...rest}
           FieldProps={{
             ...FieldProps,
             required: typeof required === 'object' ? required.value : !!required,
-            error: !!errorMessage,
-            helperText:
-              errorMessage && typeof errorMessage === 'string' ? (
-                <>
-                  {errorMessage}
-                  <br />
-                  {FieldProps?.helperText}
-                </>
-              ) : (
-                FieldProps?.helperText
-              ),
+            error: !!error,
+            helperText: error?.message ? (
+              <>
+                {error.message}
+                <br />
+                {FieldProps?.helperText}
+              </>
+            ) : (
+              FieldProps?.helperText
+            ),
           }}
           onChange={(event, value, reason) => {
             if (reason === 'clear') {

--- a/packages/controlled-form/src/lib/RadioGroup.tsx
+++ b/packages/controlled-form/src/lib/RadioGroup.tsx
@@ -1,5 +1,5 @@
 import { RadioGroup, RadioGroupProps } from '@availity/mui-form-utils';
-import { useFormContext, ControllerProps, Controller, RegisterOptions, FieldValues } from 'react-hook-form';
+import { ControllerProps, Controller, RegisterOptions, FieldValues } from 'react-hook-form';
 import { FormControl, FormLabel, FormHelperText } from '@availity/mui-form-utils';
 
 export type ControlledRadioGroupProps = RadioGroupProps & {
@@ -34,23 +34,20 @@ export const ControlledRadioGroup = ({
   value,
   ...rest
 }: ControlledRadioGroupProps) => {
-  const { control, getFieldState } = useFormContext();
-  const errorMessage = getFieldState(name).error?.message;
   return (
     <Controller
-      control={control}
       name={name}
       defaultValue={defaultValue}
       rules={{ deps, onBlur, onChange, required, shouldUnregister, value }}
       shouldUnregister={shouldUnregister}
-      render={({ field }) => (
-        <FormControl error={!!errorMessage}>
+      render={({ field, fieldState: { error } }) => (
+        <FormControl error={!!error}>
           <FormLabel required={typeof required === 'object' ? required.value : !!required}>{label}</FormLabel>
           <RadioGroup {...field} {...rest} />
           <FormHelperText>
-            {errorMessage && typeof errorMessage === 'string' ? (
+            {error?.message ? (
               <>
-                {errorMessage}
+                {error.message}
                 <br />
                 {helperText}
               </>

--- a/packages/controlled-form/src/lib/Select.stories.tsx
+++ b/packages/controlled-form/src/lib/Select.stories.tsx
@@ -44,7 +44,7 @@ export const _ControlledSelect: StoryObj<typeof ControlledSelect> = {
             disabled={!isSubmitSuccessful}
             children="Reset"
             color="secondary"
-            onClick={() => reset({ controlledSelect: undefined })}
+            onClick={() => reset({ [args.name]: '' })}
           />
           <Button type="submit" disabled={isSubmitSuccessful} children="Submit" />
         </Grid>
@@ -52,7 +52,7 @@ export const _ControlledSelect: StoryObj<typeof ControlledSelect> = {
     };
 
     return (
-      <ControlledForm values={{ controlledSelect: undefined }} onSubmit={(data) => data}>
+      <ControlledForm values={{ [args.name]: '' }} onSubmit={(data) => data} noValidate>
         <FormControl>
           <FormLabel id={`${args.id}-label`}>{args.label}</FormLabel>
           <ControlledSelect {...args} labelId={`${args.id}-label`}>

--- a/packages/controlled-form/src/lib/Select.tsx
+++ b/packages/controlled-form/src/lib/Select.tsx
@@ -1,10 +1,9 @@
 import { Select, SelectProps } from '@availity/mui-form-utils';
-import { useFormContext, RegisterOptions, FieldValues } from 'react-hook-form';
+import { RegisterOptions, FieldValues, Controller, ControllerProps } from 'react-hook-form';
 
-export type ControlledSelectProps = Omit<SelectProps, 'error' | 'required'> & { name: string } & RegisterOptions<
-    FieldValues,
-    string
-  >;
+export type ControlledSelectProps = Omit<SelectProps, 'error' | 'required'> &
+  Omit<RegisterOptions<FieldValues, string>, 'disabled' | 'valueAsNumber' | 'valueAsDate' | 'setValueAs'> &
+  Pick<ControllerProps, 'defaultValue' | 'shouldUnregister' | 'name'>;
 
 export const ControlledSelect = ({
   name,
@@ -15,23 +14,21 @@ export const ControlledSelect = ({
   min,
   pattern,
   validate,
-  setValueAs,
   disabled,
   onChange,
   onBlur,
   value,
+  defaultValue,
   shouldUnregister,
   deps,
   ...rest
 }: ControlledSelectProps) => {
-  const { register, getFieldState } = useFormContext();
-
   return (
-    <Select
-      {...rest}
-      error={!!getFieldState(name).error}
-      required={typeof required === 'object' ? required.value : !!required}
-      {...register(name, {
+    <Controller
+      name={name}
+      defaultValue={defaultValue}
+      disabled={disabled}
+      rules={{
         required,
         maxLength,
         minLength,
@@ -39,14 +36,21 @@ export const ControlledSelect = ({
         min,
         pattern,
         validate,
-        setValueAs,
-        disabled,
         onChange,
         onBlur,
         value,
         shouldUnregister,
         deps,
-      })}
+      }}
+      shouldUnregister={shouldUnregister}
+      render={({ field, fieldState: { error } }) => (
+        <Select
+          {...rest}
+          {...field}
+          error={!!error}
+          required={typeof required === 'object' ? required.value : !!required}
+        />
+      )}
     />
   );
 };

--- a/packages/controlled-form/src/lib/TextField.stories.tsx
+++ b/packages/controlled-form/src/lib/TextField.stories.tsx
@@ -43,13 +43,18 @@ export const _ControlledTextField: StoryObj<typeof ControlledTextField> = {
       } = useFormContext();
       return (
         <Grid container direction="row" justifyContent="space-between" marginTop={1}>
-          <Button disabled={!isSubmitSuccessful} children="Reset" color="secondary" onClick={() => reset()} />
+          <Button
+            disabled={!isSubmitSuccessful}
+            children="Reset"
+            color="secondary"
+            onClick={() => reset({ [args.name]: '' })}
+          />
           <Button type="submit" disabled={isSubmitSuccessful} children="Submit" />
         </Grid>
       );
     };
     return (
-      <ControlledForm values={{ controlledTextField: undefined }} onSubmit={(data) => data}>
+      <ControlledForm values={{ [args.name]: '' }} onSubmit={(data) => data}>
         <ControlledTextField {...args} />
         <Actions />
         <SubmittedValues />

--- a/packages/controlled-form/src/lib/TextField.tsx
+++ b/packages/controlled-form/src/lib/TextField.tsx
@@ -1,9 +1,9 @@
 import { TextField, TextFieldProps } from '@availity/mui-textfield';
-import { useFormContext, RegisterOptions, FieldValues } from 'react-hook-form';
+import { RegisterOptions, FieldValues, Controller, ControllerProps } from 'react-hook-form';
 
-export type ControlledTextFieldProps = Omit<TextFieldProps, 'required'> & {
-  name: string;
-} & RegisterOptions<FieldValues, string>;
+export type ControlledTextFieldProps = Omit<TextFieldProps, 'required'> &
+  Omit<RegisterOptions<FieldValues, string>, 'disabled' | 'valueAsNumber' | 'valueAsDate' | 'setValueAs'> &
+  Pick<ControllerProps, 'defaultValue' | 'shouldUnregister' | 'name'>;
 
 export const ControlledTextField = ({
   name,
@@ -15,8 +15,8 @@ export const ControlledTextField = ({
   min,
   pattern,
   validate,
-  setValueAs,
   disabled,
+  defaultValue,
   onChange,
   onBlur,
   value,
@@ -24,15 +24,12 @@ export const ControlledTextField = ({
   deps,
   ...rest
 }: ControlledTextFieldProps) => {
-  const { register, getFieldState } = useFormContext();
-
-  const errorMessage = getFieldState(name).error?.message;
-
   return (
-    <TextField
-      {...rest}
-      required={typeof required === 'object' ? required.value : !!required}
-      {...register(name, {
+    <Controller
+      name={name}
+      defaultValue={defaultValue}
+      disabled={disabled}
+      rules={{
         required,
         maxLength,
         minLength,
@@ -40,26 +37,32 @@ export const ControlledTextField = ({
         min,
         pattern,
         validate,
-        setValueAs,
-        disabled,
         onChange,
         onBlur,
         value,
         shouldUnregister,
         deps,
-      })}
-      error={!!getFieldState(name).error}
-      helperText={
-        errorMessage && typeof errorMessage === 'string' ? (
-          <>
-            {errorMessage}
-            <br />
-            {helperText}
-          </>
-        ) : (
-          helperText
-        )
-      }
+      }}
+      shouldUnregister={shouldUnregister}
+      render={({ field, fieldState: { error } }) => (
+        <TextField
+          {...rest}
+          {...field}
+          required={typeof required === 'object' ? required.value : !!required}
+          error={!!error}
+          helperText={
+            error?.message ? (
+              <>
+                {error.message}
+                <br />
+                {helperText}
+              </>
+            ) : (
+              helperText
+            )
+          }
+        />
+      )}
     />
   );
 };


### PR DESCRIPTION
RHF recommend using Controller for integrating UI libraries (even specifically calls out MUI.) It was inconsistently used. This replaces `register` usage with Controller so that it is consistent.