### PR TITLE
feat(mui-controlled-form): add ControlledSelectField

### DIFF
--- a/packages/controlled-form/src/lib/SelectField.stories.tsx
+++ b/packages/controlled-form/src/lib/SelectField.stories.tsx
@@ -1,0 +1,131 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ControlledSelectField } from './SelectField';
+import { ControlledForm } from './ControlledForm';
+import { Button } from '@availity/mui-button';
+import { useFormContext } from 'react-hook-form';
+import { Paper } from '@availity/mui-paper';
+import { Typography } from '@availity/mui-typography';
+import { Grid } from '@availity/mui-layout';
+import { MenuItem } from '@availity/mui-menu';
+
+const meta: Meta<typeof ControlledSelectField> = {
+  title: 'Form Components/Controlled Form/ControlledSelectField',
+  component: ControlledSelectField,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+export const _ControlledSelectField: StoryObj<typeof ControlledSelectField> = {
+  render: (args) => {
+    const SubmittedValues = () => {
+      const {
+        getValues,
+        formState: { isSubmitSuccessful },
+      } = useFormContext();
+
+      return isSubmitSuccessful ? (
+        <Paper sx={{ padding: '1.5rem', marginTop: '1.5rem' }}>
+          <Typography variant="h2">Submitted Values</Typography>
+          <pre>{JSON.stringify(getValues(), null, 2)}</pre>
+        </Paper>
+      ) : null;
+    };
+
+    const Actions = () => {
+      const {
+        reset,
+        formState: { isSubmitSuccessful },
+      } = useFormContext();
+      return (
+        <Grid container direction="row" justifyContent="space-between" marginTop={1}>
+          <Button
+            disabled={!isSubmitSuccessful}
+            children="Reset"
+            color="secondary"
+            onClick={() => reset({ [args.name]: '' })}
+          />
+          <Button type="submit" disabled={isSubmitSuccessful} children="Submit" />
+        </Grid>
+      );
+    };
+
+    return (
+      <ControlledForm values={{ [args.name]: '' }} onSubmit={(data) => data} noValidate>
+        <ControlledSelectField {...args}>
+          <MenuItem value={1}>Option 1</MenuItem>
+          <MenuItem value={2}>Option 2</MenuItem>
+          <MenuItem value={3}>Option 3</MenuItem>
+        </ControlledSelectField>
+        <Actions />
+        <SubmittedValues />
+      </ControlledForm>
+    );
+  },
+  args: {
+    id: 'controlledSelect',
+    name: 'controlledSelect',
+    required: 'This is required.',
+    label: 'Select Label',
+    helperText: 'Help text for the field',
+  },
+};
+
+export const _ControlledMultiSelect: StoryObj<typeof ControlledSelectField> = {
+  render: (args) => {
+    const SubmittedValues = () => {
+      const {
+        getValues,
+        formState: { isSubmitSuccessful },
+      } = useFormContext();
+
+      return isSubmitSuccessful ? (
+        <Paper sx={{ padding: '1.5rem', marginTop: '1.5rem' }}>
+          <Typography variant="h2">Submitted Values</Typography>
+          <pre>{JSON.stringify(getValues(), null, 2)}</pre>
+        </Paper>
+      ) : null;
+    };
+
+    const Actions = () => {
+      const {
+        reset,
+        formState: { isSubmitSuccessful },
+      } = useFormContext();
+      return (
+        <Grid container direction="row" justifyContent="space-between" marginTop={1}>
+          <Button
+            disabled={!isSubmitSuccessful}
+            children="Reset"
+            color="secondary"
+            onClick={() => reset({ [args.name]: [] })}
+          />
+          <Button type="submit" disabled={isSubmitSuccessful} children="Submit" />
+        </Grid>
+      );
+    };
+
+    return (
+      <ControlledForm values={{ [args.name]: [] }} onSubmit={(data) => data} noValidate>
+        <ControlledSelectField {...args}>
+          <MenuItem value={1}>Option 1</MenuItem>
+          <MenuItem value={2}>Option 2</MenuItem>
+          <MenuItem value={3}>Option 3</MenuItem>
+          <MenuItem value={4}>Option 4</MenuItem>
+          <MenuItem value={5}>Option 5</MenuItem>
+          <MenuItem value={6}>Option 6</MenuItem>
+        </ControlledSelectField>
+        <Actions />
+        <SubmittedValues />
+      </ControlledForm>
+    );
+  },
+  args: {
+    id: 'controlledMutliSelect',
+    name: 'controlledMutliSelect',
+    required: 'This is required.',
+    label: 'Select Label',
+    helperText: 'Help text for the field',
+    multiple: true,
+  },
+};

--- a/packages/controlled-form/src/lib/SelectField.test.tsx
+++ b/packages/controlled-form/src/lib/SelectField.test.tsx
@@ -1,0 +1,74 @@
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { useFormContext } from 'react-hook-form';
+import { Paper } from '@availity/mui-paper';
+import { Typography } from '@availity/mui-typography';
+import { Grid } from '@availity/mui-layout';
+import { Button } from '@availity/mui-button';
+import { ControlledForm } from './ControlledForm';
+import { ControlledSelectField } from './SelectField';
+import { MenuItem } from '@availity/mui-menu';
+
+const SubmittedValues = () => {
+  const {
+    getValues,
+    formState: { isSubmitSuccessful },
+  } = useFormContext();
+
+  return isSubmitSuccessful ? (
+    <Paper sx={{ padding: '1.5rem', marginTop: '1.5rem' }}>
+      <Typography variant="h2">Submitted Values</Typography>
+      <pre data-testid="result">{JSON.stringify(getValues(), null, 2)}</pre>
+    </Paper>
+  ) : null;
+};
+
+const Actions = () => {
+  const {
+    formState: { isSubmitSuccessful },
+  } = useFormContext();
+  return (
+    <Grid container direction="row" justifyContent="space-between">
+      <Button type="submit" disabled={isSubmitSuccessful} children="Submit" />
+    </Grid>
+  );
+};
+
+const onSubmit = jest.fn();
+
+describe('ControlledSelect', () => {
+  test('should render the error styling if an error is returned', async () => {
+    const screen = render(
+      <ControlledForm values={{ controlledSelect: '' }} onSubmit={onSubmit}>
+        <ControlledSelectField
+          name="controlledSelect"
+          helperText="Help text"
+          label="Select Label"
+          required="This field is required."
+        >
+          <MenuItem value={1}>Option 1</MenuItem>
+          <MenuItem value={2}>Option 2</MenuItem>
+          <MenuItem value={3}>Option 3</MenuItem>
+        </ControlledSelectField>
+        <Actions />
+        <SubmittedValues />
+      </ControlledForm>
+    );
+
+    expect(screen.getByText('Help text')).toBeDefined();
+    expect(screen.getByText('Select Label')).toBeDefined();
+
+    const dropdown = screen.getByRole('combobox');
+    fireEvent.click(dropdown);
+    fireEvent.keyDown(dropdown, { key: 'ArrowDown' });
+
+    fireEvent.click(screen.getByText('Option 1'));
+
+    fireEvent.click(screen.getByText('Submit'));
+
+    await waitFor(() => {
+      const result = screen.getByTestId('result');
+      const controlledSelectValue = JSON.parse(result.innerHTML).controlledSelect;
+      expect(controlledSelectValue).toBe(1);
+    });
+  });
+});

--- a/packages/controlled-form/src/lib/SelectField.tsx
+++ b/packages/controlled-form/src/lib/SelectField.tsx
@@ -1,0 +1,74 @@
+import { FormControl, FormHelperText, FormLabel, Select, SelectProps } from '@availity/mui-form-utils';
+import { RegisterOptions, FieldValues, Controller, ControllerProps } from 'react-hook-form';
+
+export type ControlledSelectFieldProps = Omit<SelectProps, 'error' | 'required'> &
+  Omit<RegisterOptions<FieldValues, string>, 'disabled' | 'valueAsNumber' | 'valueAsDate' | 'setValueAs'> &
+  Pick<ControllerProps, 'defaultValue' | 'shouldUnregister' | 'name'> & { helperText?: React.ReactNode };
+
+export const ControlledSelectField = ({
+  name,
+  required,
+  maxLength,
+  minLength,
+  max,
+  min,
+  pattern,
+  validate,
+  disabled,
+  onChange,
+  onBlur,
+  value,
+  defaultValue,
+  shouldUnregister,
+  deps,
+  label,
+  helperText,
+  ...rest
+}: ControlledSelectFieldProps) => {
+  return (
+    <Controller
+      name={name}
+      defaultValue={defaultValue}
+      disabled={disabled}
+      rules={{
+        required,
+        maxLength,
+        minLength,
+        max,
+        min,
+        pattern,
+        validate,
+        onChange,
+        onBlur,
+        value,
+        shouldUnregister,
+        deps,
+      }}
+      shouldUnregister={shouldUnregister}
+      render={({ field, fieldState: { error } }) => (
+        <FormControl error={!!error} disabled={field.disabled}>
+          {label && (
+            <FormLabel required={!!required} htmlFor={rest.id}>
+              {label}
+            </FormLabel>
+          )}
+          <Select
+            {...rest}
+            {...field}
+            error={!!error}
+            required={typeof required === 'object' ? required.value : !!required}
+          />
+          {error?.message ? (
+            <FormHelperText error>
+              {error.message}
+              <br />
+              {helperText}
+            </FormHelperText>
+          ) : (
+            <FormHelperText>{helperText}</FormHelperText>
+          )}
+        </FormControl>
+      )}
+    />
+  );
+};


### PR DESCRIPTION
Currently, the ControlledSelect is just the select. This requires devs to build out the label, helperText, and most importantly validation styles on those (e.g. the story for ControlledSelect doesn't style the label for required or errors.) The problem with validation styles is... this is a controlled field and the current validation state is not easy to access (to the point where having to access it defeats the purpose of ControlledSelect)

The proposal here is to have a Select "Field" similar to TextField (and previous libraries' "Field" components) where the label, helper text, and validation message is handled. IMO, needing these things is typical usage for a form component.