### PR TITLE
fix(mui-progress): hide percentage for indeterminate

### DIFF
--- a/packages/progress/src/lib/LinearProgress.test.tsx
+++ b/packages/progress/src/lib/LinearProgress.test.tsx
@@ -25,4 +25,9 @@ describe('LinearProgress', () => {
     expect(screen.getByText('100%')).toBeDefined();
     expect(svgEl.classList.toString()).toContain('MuiSvgIcon-root');
   });
+
+  test('should not show value as percentage for indeterminate', () => {
+    render(<LinearProgress hidePercentage value={50} />);
+    expect(screen.queryByText('50%')).toBeNull();
+  });
 });

--- a/packages/progress/src/lib/LinearProgress.tsx
+++ b/packages/progress/src/lib/LinearProgress.tsx
@@ -3,16 +3,18 @@ import { Box, Stack } from '@availity/mui-layout';
 import { Typography } from '@availity/mui-typography';
 import MuiLinearProgress, { LinearProgressProps as MuiLinearProgressProps } from '@mui/material/LinearProgress';
 
-export type LinearProgressProps = Omit<MuiLinearProgressProps, 'color'>;
+export type LinearProgressProps = Omit<MuiLinearProgressProps, 'color'> & { hidePercentage?: boolean };
 
-export const LinearProgress = ({ variant = 'determinate', value = 0, sx, ...props }: LinearProgressProps) => {
+export const LinearProgress = ({ variant = 'determinate', value = 0, sx, hidePercentage = false, ...props }: LinearProgressProps) => {
   return (
     <Stack direction="row" alignItems="center">
       <Box sx={{ width: '100%', mr: 0.5 }}>
         <MuiLinearProgress variant={variant} {...props} value={value} color="success" sx={{ width: '100%', ...sx }} />
       </Box>
       {value === 100 && <SuccessCircleIcon color="success" data-icon="complete" />}
-      <Typography variant="body2" sx={{ color: 'text.secondary', ml: 1 }}>{`${Math.round(value)}%`}</Typography>
+      {!hidePercentage && (
+        <Typography variant="body2" sx={{ color: 'text.secondary', ml: 1 }}>{`${Math.round(value)}%`}</Typography>
+      )}
     </Stack>
   );
 };


### PR DESCRIPTION
The ticket says "this ticket will turn off value prop (%) for LinearProgress indeterminate variant" so that is how it was coded. Let me know if this should be more configurable... allowing the percentage to be shown or not shown based on a prop regardless of the variant.