### PR TITLE
fix(mui-controlled-form): allow validation objects and forward required

### DIFF
--- a/packages/controlled-form/src/lib/AsyncAutocomplete.test.tsx
+++ b/packages/controlled-form/src/lib/AsyncAutocomplete.test.tsx
@@ -66,17 +66,17 @@ describe('ControlledAsyncAutocomplete', () => {
   });
 
   test('should loadOptions successfully', async () => {
-      const screen = render(
-        <QueryClientProvider client={client}>
-          <TestForm UseFormOptions={{values: { controlledAutocomplete: undefined }}} onSubmit={onSubmit}>
-            <ControlledAsyncAutocomplete
-              name="controlledAsyncAutocomplete"
-              FieldProps={{ label: 'Async Select', helperText: 'Helper Text', fullWidth: false }}
-              getOptionLabel={(val: Option) => val.label}
-              loadOptions={loadOptions}
-              limit={10}
-              queryKey="example"
-            />
+    const screen = render(
+      <QueryClientProvider client={client}>
+        <TestForm UseFormOptions={{ values: { controlledAutocomplete: undefined } }} onSubmit={onSubmit}>
+          <ControlledAsyncAutocomplete
+            name="controlledAsyncAutocomplete"
+            FieldProps={{ label: 'Async Select', helperText: 'Helper Text', fullWidth: false }}
+            getOptionLabel={(val: Option) => val.label}
+            loadOptions={loadOptions}
+            limit={10}
+            queryKey="example"
+          />
         </TestForm>
       </QueryClientProvider>
     );
@@ -91,7 +91,7 @@ describe('ControlledAsyncAutocomplete', () => {
   test('should set the value and submit the form data', async () => {
     const screen = render(
       <QueryClientProvider client={client}>
-        <TestForm UseFormOptions={{values: { controlledAutocomplete: undefined }}} onSubmit={onSubmit}>
+        <TestForm UseFormOptions={{ values: { controlledAutocomplete: undefined } }} onSubmit={onSubmit}>
           <ControlledAsyncAutocomplete
             name="controlledAsyncAutocomplete"
             FieldProps={{ label: 'Async Select', helperText: 'Helper Text', fullWidth: false }}
@@ -100,9 +100,9 @@ describe('ControlledAsyncAutocomplete', () => {
             limit={10}
             queryKey="example"
           />
-      </TestForm>
-    </QueryClientProvider>
-  );
+        </TestForm>
+      </QueryClientProvider>
+    );
 
     const dropdown = screen.getByRole('combobox');
     fireEvent.click(dropdown);
@@ -121,6 +121,70 @@ describe('ControlledAsyncAutocomplete', () => {
       expect(controlledAsyncAutocompleteValue.label).toBe('Option 1');
       expect(controlledAsyncAutocompleteValue.value).toBe(1);
       expect(controlledAsyncAutocompleteValue.id).toBeDefined(); // This is a unique id
+    });
+  });
+
+  describe('when using rules', () => {
+    describe('when required', () => {
+      test('should indicate it is required when passing a string', async () => {
+        const screen = render(
+          <QueryClientProvider client={client}>
+            <TestForm UseFormOptions={{ values: { controlledAutocomplete: undefined } }} onSubmit={onSubmit}>
+              <ControlledAsyncAutocomplete
+                name="controlledAsyncAutocomplete"
+                FieldProps={{ label: 'Async Select', helperText: 'Helper Text', fullWidth: false }}
+                getOptionLabel={(val: Option) => val.label}
+                loadOptions={loadOptions}
+                limit={10}
+                queryKey="example"
+                rules={{ required: 'This field is required' }}
+              />
+            </TestForm>
+          </QueryClientProvider>
+        );
+
+        expect(screen.getByText('*')).toBeDefined();
+      });
+
+      test('should indicate it is required when passing an object with true', async () => {
+        const screen = render(
+          <QueryClientProvider client={client}>
+            <TestForm UseFormOptions={{ values: { controlledAutocomplete: undefined } }} onSubmit={onSubmit}>
+              <ControlledAsyncAutocomplete
+                name="controlledAsyncAutocomplete"
+                FieldProps={{ label: 'Async Select', helperText: 'Helper Text', fullWidth: false }}
+                getOptionLabel={(val: Option) => val.label}
+                loadOptions={loadOptions}
+                limit={10}
+                queryKey="example"
+                rules={{ required: { value: true, message: 'This field is required' } }}
+              />
+            </TestForm>
+          </QueryClientProvider>
+        );
+
+        expect(screen.getByText('*')).toBeDefined();
+      });
+
+      test('should not indicate it is required when passing an object with false', async () => {
+        const screen = render(
+          <QueryClientProvider client={client}>
+            <TestForm UseFormOptions={{ values: { controlledAutocomplete: undefined } }} onSubmit={onSubmit}>
+              <ControlledAsyncAutocomplete
+                name="controlledAsyncAutocomplete"
+                FieldProps={{ label: 'Async Select', helperText: 'Helper Text', fullWidth: false }}
+                getOptionLabel={(val: Option) => val.label}
+                loadOptions={loadOptions}
+                limit={10}
+                queryKey="example"
+                rules={{ required: { value: false, message: 'This field is required' } }}
+              />
+            </TestForm>
+          </QueryClientProvider>
+        );
+
+        expect(screen.queryByText('*')).toBeNull();
+      });
     });
   });
 });

--- a/packages/controlled-form/src/lib/AsyncAutocomplete.tsx
+++ b/packages/controlled-form/src/lib/AsyncAutocomplete.tsx
@@ -9,11 +9,12 @@ export type ControlledAsyncAutocompleteProps<
   DisableClearable extends boolean | undefined,
   FreeSolo extends boolean | undefined,
   ChipComponent extends React.ElementType = ChipTypeMap['defaultComponent'],
-> = Omit<AsyncAutocompleteProps<Option, Multiple, DisableClearable, FreeSolo, ChipComponent>,
-'onBlur' | 'onChange' | 'value' | 'name'
-> & Pick<RegisterOptions<FieldValues, string>,
-'onBlur' | 'onChange' | 'value'
-> & ControllerProps
+> = Omit<
+  AsyncAutocompleteProps<Option, Multiple, DisableClearable, FreeSolo, ChipComponent>,
+  'onBlur' | 'onChange' | 'value' | 'name'
+> &
+  Pick<RegisterOptions<FieldValues, string>, 'onBlur' | 'onChange' | 'value'> &
+  ControllerProps;
 
 export const ControlledAsyncAutocomplete = <
   Option,
@@ -47,6 +48,7 @@ export const ControlledAsyncAutocomplete = <
         <AsyncAutocomplete
           {...rest}
           FieldProps={{
+            required: typeof rules.required === 'object' ? rules.required.value : !!rules.required,
             ...FieldProps,
             error: !!error,
             helperText: error?.message ? (
@@ -58,7 +60,7 @@ export const ControlledAsyncAutocomplete = <
             ) : (
               FieldProps?.helperText
             ),
-            inputRef:ref
+            inputRef: ref,
           }}
           onChange={(event, value, reason) => {
             if (reason === 'clear') {

--- a/packages/controlled-form/src/lib/Autocomplete.test.tsx
+++ b/packages/controlled-form/src/lib/Autocomplete.test.tsx
@@ -13,11 +13,8 @@ describe('ControlledAsyncAutocomplete', () => {
 
   test('should set the value and submit the form', async () => {
     const screen = render(
-      <TestForm UseFormOptions={{values: { controlledAutocomplete: null}}} onSubmit={onSubmit}>
-        <ControlledAutocomplete
-          name="controlledAutocomplete"
-          options={['Option 1', 'Option 2']}
-        />
+      <TestForm UseFormOptions={{ values: { controlledAutocomplete: null } }} onSubmit={onSubmit}>
+        <ControlledAutocomplete name="controlledAutocomplete" options={['Option 1', 'Option 2']} />
       </TestForm>
     );
 
@@ -35,6 +32,55 @@ describe('ControlledAsyncAutocomplete', () => {
     await waitFor(() => {
       const controlledAutocompleteValue = JSON.parse(result.innerHTML).controlledAutocomplete;
       expect(controlledAutocompleteValue).toBe('Option 1');
+    });
+  });
+
+  describe('when using rules', () => {
+    describe('when required', () => {
+      test('should indicate it is required when passing a string', async () => {
+        const screen = render(
+          <TestForm UseFormOptions={{ values: { controlledAutocomplete: null } }} onSubmit={onSubmit}>
+            <ControlledAutocomplete
+              FieldProps={{ label: 'Autocomplete Label' }}
+              name="controlledAutocomplete"
+              options={['Option 1', 'Option 2']}
+              rules={{ required: 'This field is required' }}
+            />
+          </TestForm>
+        );
+
+        expect(screen.getByText('*')).toBeDefined();
+      });
+
+      test('should indicate it is required when passing an object with true', async () => {
+        const screen = render(
+          <TestForm UseFormOptions={{ values: { controlledAutocomplete: null } }} onSubmit={onSubmit}>
+            <ControlledAutocomplete
+              FieldProps={{ label: 'Autocomplete Label' }}
+              name="controlledAutocomplete"
+              options={['Option 1', 'Option 2']}
+              rules={{ required: { value: true, message: 'This field is required' } }}
+            />
+          </TestForm>
+        );
+
+        expect(screen.getByText('*')).toBeDefined();
+      });
+
+      test('should not indicate it is required when passing an object with false', async () => {
+        const screen = render(
+          <TestForm UseFormOptions={{ values: { controlledAutocomplete: null } }} onSubmit={onSubmit}>
+            <ControlledAutocomplete
+              FieldProps={{ label: 'Autocomplete Label' }}
+              name="controlledAutocomplete"
+              options={['Option 1', 'Option 2']}
+              rules={{ required: { value: false, message: 'This field is required' } }}
+            />
+          </TestForm>
+        );
+
+        expect(screen.queryByText('*')).toBeNull();
+      });
     });
   });
 });

--- a/packages/controlled-form/src/lib/Autocomplete.tsx
+++ b/packages/controlled-form/src/lib/Autocomplete.tsx
@@ -10,11 +10,11 @@ export type ControlledAutocompleteProps<
   FreeSolo extends boolean | undefined,
   ChipComponent extends React.ElementType = ChipTypeMap['defaultComponent'],
 > = Omit<
-AutocompleteProps<T, Multiple, DisableClearable, FreeSolo, ChipComponent>,
-'onBlur' | 'onChange' | 'value' | 'name'
-> & Pick<RegisterOptions<FieldValues, string>,
-'onBlur' | 'onChange' | 'value'
-> & ControllerProps;
+  AutocompleteProps<T, Multiple, DisableClearable, FreeSolo, ChipComponent>,
+  'onBlur' | 'onChange' | 'value' | 'name'
+> &
+  Pick<RegisterOptions<FieldValues, string>, 'onBlur' | 'onChange' | 'value'> &
+  ControllerProps;
 
 export const ControlledAutocomplete = <
   T,
@@ -49,18 +49,19 @@ export const ControlledAutocomplete = <
         <Autocomplete
           {...rest}
           FieldProps={{
+            required: typeof rules.required === 'object' ? rules.required.value : !!rules.required,
             ...FieldProps,
             error: !!error,
             helperText: error?.message ? (
-                <>
-                  {error.message}
-                  <br />
-                  {FieldProps?.helperText}
-                </>
-              ) : (
-                FieldProps?.helperText
-              ),
-            inputRef: ref
+              <>
+                {error.message}
+                <br />
+                {FieldProps?.helperText}
+              </>
+            ) : (
+              FieldProps?.helperText
+            ),
+            inputRef: ref,
           }}
           onChange={(event, value, reason) => {
             if (reason === 'clear') {

--- a/packages/controlled-form/src/lib/Checkbox.tsx
+++ b/packages/controlled-form/src/lib/Checkbox.tsx
@@ -2,11 +2,9 @@ import { Checkbox, CheckboxProps } from '@availity/mui-checkbox';
 import { RegisterOptions, FieldValues, Controller } from 'react-hook-form';
 import { ControllerProps } from './Types';
 
-export type ControlledCheckboxProps = Omit<CheckboxProps,
-  'disabled' | 'onBlur' | 'onChange' | 'value' | 'name'
-> & Pick<RegisterOptions<FieldValues, string>,
-  'disabled' | 'onBlur' | 'onChange' | 'value'
-> & ControllerProps;
+export type ControlledCheckboxProps = Omit<CheckboxProps, 'disabled' | 'onBlur' | 'onChange' | 'value' | 'name'> &
+  Pick<RegisterOptions<FieldValues, string>, 'disabled' | 'onBlur' | 'onChange' | 'value'> &
+  ControllerProps;
 
 export const ControlledCheckbox = ({
   name,
@@ -33,7 +31,13 @@ export const ControlledCheckbox = ({
       }}
       shouldUnregister={shouldUnregister}
       render={({ field }) => (
-        <Checkbox {...rest} {...field} checked={field.value} onChange={(e) => field.onChange(e.target.checked)} />
+        <Checkbox
+          required={typeof rules.required === 'object' ? rules.required.value : !!rules.required}
+          {...rest}
+          {...field}
+          checked={field.value}
+          onChange={(e) => field.onChange(e.target.checked)}
+        />
       )}
     />
   );

--- a/packages/controlled-form/src/lib/CodesAutocomplete.test.tsx
+++ b/packages/controlled-form/src/lib/CodesAutocomplete.test.tsx
@@ -43,9 +43,9 @@ describe('ControlledAsyncAutocomplete', () => {
             }}
             limit={15}
           />
-      </TestForm>
-    </QueryClientProvider>
-  );
+        </TestForm>
+      </QueryClientProvider>
+    );
 
     const dropdown = screen.getByRole('combobox');
     fireEvent.click(dropdown);
@@ -55,20 +55,20 @@ describe('ControlledAsyncAutocomplete', () => {
   });
 
   test('should set the value and submit the form data', async () => {
-      const screen = render(
-        <QueryClientProvider client={client}>
-          <TestForm onSubmit={onSubmit}>
-            <ControlledCodesAutocomplete
-              name="controlledCodesAutocomplete"
-              list="ABC"
-              FieldProps={{
-                label: 'Code Select',
-                helperText: 'Select a code from the list',
-                placeholder: 'Select...',
-                fullWidth: false,
-              }}
-              limit={15}
-            />
+    const screen = render(
+      <QueryClientProvider client={client}>
+        <TestForm onSubmit={onSubmit}>
+          <ControlledCodesAutocomplete
+            name="controlledCodesAutocomplete"
+            list="ABC"
+            FieldProps={{
+              label: 'Code Select',
+              helperText: 'Select a code from the list',
+              placeholder: 'Select...',
+              fullWidth: false,
+            }}
+            limit={15}
+          />
         </TestForm>
       </QueryClientProvider>
     );
@@ -89,6 +89,79 @@ describe('ControlledAsyncAutocomplete', () => {
       const controlledCodesAutocompleteValue = JSON.parse(result.innerHTML).controlledCodesAutocomplete;
       expect(controlledCodesAutocompleteValue.code).toBe('171100000X');
       expect(controlledCodesAutocompleteValue.value).toBe('Acupuncturist');
+    });
+  });
+
+  describe('when using rules', () => {
+    describe('when required', () => {
+      test('should indicate it is required when passing a string', async () => {
+        const screen = render(
+          <QueryClientProvider client={client}>
+            <TestForm onSubmit={onSubmit}>
+              <ControlledCodesAutocomplete
+                name="controlledCodesAutocomplete"
+                list="ABC"
+                FieldProps={{
+                  label: 'Code Select',
+                  helperText: 'Select a code from the list',
+                  placeholder: 'Select...',
+                  fullWidth: false,
+                }}
+                limit={15}
+                rules={{ required: 'This field is required' }}
+              />
+            </TestForm>
+          </QueryClientProvider>
+        );
+
+        expect(screen.getByText('*')).toBeDefined();
+      });
+
+      test('should indicate it is required when passing an object with true', async () => {
+        const screen = render(
+          <QueryClientProvider client={client}>
+            <TestForm onSubmit={onSubmit}>
+              <ControlledCodesAutocomplete
+                name="controlledCodesAutocomplete"
+                list="ABC"
+                FieldProps={{
+                  label: 'Code Select',
+                  helperText: 'Select a code from the list',
+                  placeholder: 'Select...',
+                  fullWidth: false,
+                }}
+                limit={15}
+                rules={{ required: { value: true, message: 'This field is required' } }}
+              />
+            </TestForm>
+          </QueryClientProvider>
+        );
+
+        expect(screen.getByText('*')).toBeDefined();
+      });
+
+      test('should not indicate it is required when passing an object with false', async () => {
+        const screen = render(
+          <QueryClientProvider client={client}>
+            <TestForm onSubmit={onSubmit}>
+              <ControlledCodesAutocomplete
+                name="controlledCodesAutocomplete"
+                list="ABC"
+                FieldProps={{
+                  label: 'Code Select',
+                  helperText: 'Select a code from the list',
+                  placeholder: 'Select...',
+                  fullWidth: false,
+                }}
+                limit={15}
+                rules={{ required: { value: false, message: 'This field is required' } }}
+              />
+            </TestForm>
+          </QueryClientProvider>
+        );
+
+        expect(screen.queryByText('*')).toBeNull();
+      });
     });
   });
 });

--- a/packages/controlled-form/src/lib/CodesAutocomplete.tsx
+++ b/packages/controlled-form/src/lib/CodesAutocomplete.tsx
@@ -2,11 +2,9 @@ import { CodesAutocomplete, CodesAutocompleteProps } from '@availity/mui-autocom
 import { Controller, RegisterOptions, FieldValues } from 'react-hook-form';
 import { ControllerProps } from './Types';
 
-export type ControlledCodesAutocompleteProps = Omit<CodesAutocompleteProps,
-'onBlur' | 'onChange' | 'value' | 'name'
-> & Pick<RegisterOptions<FieldValues, string>,
-'onBlur' | 'onChange' | 'value'
-> & ControllerProps;
+export type ControlledCodesAutocompleteProps = Omit<CodesAutocompleteProps, 'onBlur' | 'onChange' | 'value' | 'name'> &
+  Pick<RegisterOptions<FieldValues, string>, 'onBlur' | 'onChange' | 'value'> &
+  ControllerProps;
 
 export const ControlledCodesAutocomplete = ({
   name,
@@ -35,6 +33,7 @@ export const ControlledCodesAutocomplete = ({
         <CodesAutocomplete
           {...rest}
           FieldProps={{
+            required: typeof rules.required === 'object' ? rules.required.value : !!rules.required,
             ...FieldProps,
             error: !!error,
             helperText: error?.message ? (
@@ -46,7 +45,7 @@ export const ControlledCodesAutocomplete = ({
             ) : (
               FieldProps?.helperText
             ),
-            inputRef:ref
+            inputRef: ref,
           }}
           onChange={(event, value, reason) => {
             if (reason === 'clear') {

--- a/packages/controlled-form/src/lib/Datepicker.test.tsx
+++ b/packages/controlled-form/src/lib/Datepicker.test.tsx
@@ -10,7 +10,7 @@ describe('Datepicker', () => {
   test('should render successfully and submit selection', async () => {
     const screen = render(
       <ThemeProvider>
-        <TestForm UseFormOptions={{values: { controlledDatepicker: null}}} onSubmit={onSubmit}>
+        <TestForm UseFormOptions={{ values: { controlledDatepicker: null } }} onSubmit={onSubmit}>
           <ControlledDatepicker
             name="controlledDatepicker"
             FieldProps={{
@@ -38,4 +38,71 @@ describe('Datepicker', () => {
       expect(dayjs(controlledDatepickerValue).isValid()).toBeTruthy();
     });
   }, 10000);
+
+  describe('when using rules', () => {
+    describe('when required', () => {
+      test('should indicate it is required when passing a string', async () => {
+        const screen = render(
+          <ThemeProvider>
+            <TestForm UseFormOptions={{ values: { controlledDatepicker: null } }} onSubmit={onSubmit}>
+              <ControlledDatepicker
+                name="controlledDatepicker"
+                FieldProps={{
+                  fullWidth: false,
+                  helperText: 'Help text for the field',
+                  helpTopicId: '1234',
+                  label: 'Date',
+                }}
+                rules={{ required: 'This field is required' }}
+              />
+            </TestForm>
+          </ThemeProvider>
+        );
+
+        expect(screen.getByText('*')).toBeDefined();
+      });
+
+      test('should indicate it is required when passing an object with true', async () => {
+        const screen = render(
+          <ThemeProvider>
+            <TestForm UseFormOptions={{ values: { controlledDatepicker: null } }} onSubmit={onSubmit}>
+              <ControlledDatepicker
+                name="controlledDatepicker"
+                FieldProps={{
+                  fullWidth: false,
+                  helperText: 'Help text for the field',
+                  helpTopicId: '1234',
+                  label: 'Date',
+                }}
+                rules={{ required: { value: true, message: 'This field is required' } }}
+              />
+            </TestForm>
+          </ThemeProvider>
+        );
+
+        expect(screen.getByText('*')).toBeDefined();
+      });
+
+      test('should not indicate it is required when passing an object with false', async () => {
+        const screen = render(
+          <ThemeProvider>
+            <TestForm UseFormOptions={{ values: { controlledDatepicker: null } }} onSubmit={onSubmit}>
+              <ControlledDatepicker
+                name="controlledDatepicker"
+                FieldProps={{
+                  fullWidth: false,
+                  helperText: 'Help text for the field',
+                  helpTopicId: '1234',
+                  label: 'Date',
+                }}
+                rules={{ required: { value: false, message: 'This field is required' } }}
+              />
+            </TestForm>
+          </ThemeProvider>
+        );
+
+        expect(screen.queryByText('*')).toBeNull();
+      });
+    });
+  });
 });

--- a/packages/controlled-form/src/lib/Datepicker.tsx
+++ b/packages/controlled-form/src/lib/Datepicker.tsx
@@ -2,11 +2,9 @@ import { Datepicker, DatepickerProps } from '@availity/mui-datepicker';
 import { RegisterOptions, FieldValues, Controller } from 'react-hook-form';
 import { ControllerProps } from './Types';
 
-export type ControlledDatepickerProps = Omit<DatepickerProps,
-  'onBlur' | 'onChange' | 'value' | 'name'
-> & Pick<RegisterOptions<FieldValues, string>,
-  'onBlur' | 'onChange' | 'value'
-> & ControllerProps;
+export type ControlledDatepickerProps = Omit<DatepickerProps, 'onBlur' | 'onChange' | 'value' | 'name'> &
+  Pick<RegisterOptions<FieldValues, string>, 'onBlur' | 'onChange' | 'value'> &
+  ControllerProps;
 
 export const ControlledDatepicker = ({
   name,
@@ -35,6 +33,7 @@ export const ControlledDatepicker = ({
         <Datepicker
           {...rest}
           FieldProps={{
+            required: typeof rules.required === 'object' ? rules.required.value : !!rules.required,
             ...FieldProps,
             error: !!error,
             helperText: error ? (
@@ -48,7 +47,7 @@ export const ControlledDatepicker = ({
             ),
             inputRef: ref,
             inputProps: {
-              onBlur: onBlur
+              onBlur: onBlur,
             },
           }}
           onChange={onChange}

--- a/packages/controlled-form/src/lib/Input.tsx
+++ b/packages/controlled-form/src/lib/Input.tsx
@@ -2,11 +2,9 @@ import { Input, InputProps } from '@availity/mui-form-utils';
 import { RegisterOptions, FieldValues, Controller } from 'react-hook-form';
 import { ControllerProps } from './Types';
 
-export type ControlledInputProps = Omit<InputProps,
-'onBlur' | 'onChange' | 'value' | 'name'
-> & Pick<RegisterOptions<FieldValues, string>,
-'onBlur' | 'onChange' | 'value'
-> & ControllerProps
+export type ControlledInputProps = Omit<InputProps, 'onBlur' | 'onChange' | 'value' | 'name'> &
+  Pick<RegisterOptions<FieldValues, string>, 'onBlur' | 'onChange' | 'value'> &
+  ControllerProps;
 
 export const ControlledInput = ({
   name,
@@ -34,6 +32,7 @@ export const ControlledInput = ({
       shouldUnregister={shouldUnregister}
       render={({ field, fieldState: { error } }) => (
         <Input
+          required={typeof rules.required === 'object' ? rules.required.value : !!rules.required}
           {...rest}
           {...field}
           error={!!error}

--- a/packages/controlled-form/src/lib/OrganizationAutocomplete.test.tsx
+++ b/packages/controlled-form/src/lib/OrganizationAutocomplete.test.tsx
@@ -32,15 +32,15 @@ describe('ControlledOrganizationAutocomplete', () => {
     const screen = render(
       <QueryClientProvider client={client}>
         <TestForm onSubmit={onSubmit}>
-            <ControlledOrganizationAutocomplete
-              name="controlledOrganizationAutocomplete"
-              FieldProps={{
-                label: 'Organization Select',
-                helperText: 'Select an Organization from the list',
-                placeholder: 'Select...',
-                fullWidth: false,
-              }}
-            />
+          <ControlledOrganizationAutocomplete
+            name="controlledOrganizationAutocomplete"
+            FieldProps={{
+              label: 'Organization Select',
+              helperText: 'Select an Organization from the list',
+              placeholder: 'Select...',
+              fullWidth: false,
+            }}
+          />
         </TestForm>
       </QueryClientProvider>
     );
@@ -56,15 +56,15 @@ describe('ControlledOrganizationAutocomplete', () => {
     const screen = render(
       <QueryClientProvider client={client}>
         <TestForm onSubmit={onSubmit}>
-            <ControlledOrganizationAutocomplete
-              name="controlledOrganizationAutocomplete"
-              FieldProps={{
-                label: 'Organization Select',
-                helperText: 'Select an Organization from the list',
-                placeholder: 'Select...',
-                fullWidth: false,
-              }}
-            />
+          <ControlledOrganizationAutocomplete
+            name="controlledOrganizationAutocomplete"
+            FieldProps={{
+              label: 'Organization Select',
+              helperText: 'Select an Organization from the list',
+              placeholder: 'Select...',
+              fullWidth: false,
+            }}
+          />
         </TestForm>
       </QueryClientProvider>
     );
@@ -86,6 +86,73 @@ describe('ControlledOrganizationAutocomplete', () => {
       expect(controlledCodesAutocompleteValue.customerId).toBe('1');
       expect(controlledCodesAutocompleteValue.name).toBe('Organization 1');
       expect(controlledCodesAutocompleteValue.id).toBeDefined();
+    });
+  });
+
+  describe('when using rules', () => {
+    describe('when required', () => {
+      test('should indicate it is required when passing a string', async () => {
+        const screen = render(
+          <QueryClientProvider client={client}>
+            <TestForm onSubmit={onSubmit}>
+              <ControlledOrganizationAutocomplete
+                name="controlledOrganizationAutocomplete"
+                FieldProps={{
+                  label: 'Organization Select',
+                  helperText: 'Select an Organization from the list',
+                  placeholder: 'Select...',
+                  fullWidth: false,
+                }}
+                rules={{ required: 'This field is required' }}
+              />
+            </TestForm>
+          </QueryClientProvider>
+        );
+
+        expect(screen.getByText('*')).toBeDefined();
+      });
+
+      test('should indicate it is required when passing an object with true', async () => {
+        const screen = render(
+          <QueryClientProvider client={client}>
+            <TestForm onSubmit={onSubmit}>
+              <ControlledOrganizationAutocomplete
+                name="controlledOrganizationAutocomplete"
+                FieldProps={{
+                  label: 'Organization Select',
+                  helperText: 'Select an Organization from the list',
+                  placeholder: 'Select...',
+                  fullWidth: false,
+                }}
+                rules={{ required: { value: true, message: 'This field is required' } }}
+              />
+            </TestForm>
+          </QueryClientProvider>
+        );
+
+        expect(screen.getByText('*')).toBeDefined();
+      });
+
+      test('should not indicate it is required when passing an object with false', async () => {
+        const screen = render(
+          <QueryClientProvider client={client}>
+            <TestForm onSubmit={onSubmit}>
+              <ControlledOrganizationAutocomplete
+                name="controlledOrganizationAutocomplete"
+                FieldProps={{
+                  label: 'Organization Select',
+                  helperText: 'Select an Organization from the list',
+                  placeholder: 'Select...',
+                  fullWidth: false,
+                }}
+                rules={{ required: { value: false, message: 'This field is required' } }}
+              />
+            </TestForm>
+          </QueryClientProvider>
+        );
+
+        expect(screen.queryByText('*')).toBeNull();
+      });
     });
   });
 });

--- a/packages/controlled-form/src/lib/OrganizationAutocomplete.tsx
+++ b/packages/controlled-form/src/lib/OrganizationAutocomplete.tsx
@@ -2,11 +2,9 @@ import { OrganizationAutocomplete, OrgAutocompleteProps } from '@availity/mui-au
 import { Controller, RegisterOptions, FieldValues } from 'react-hook-form';
 import { ControllerProps } from './Types';
 
-export type ControlledOrgAutocompleteProps = Omit<OrgAutocompleteProps,
-'onBlur' | 'onChange' | 'value' | 'name'
-> & Pick<RegisterOptions<FieldValues, string>,
-'onBlur' | 'onChange' | 'value'
-> & ControllerProps;
+export type ControlledOrgAutocompleteProps = Omit<OrgAutocompleteProps, 'onBlur' | 'onChange' | 'value' | 'name'> &
+  Pick<RegisterOptions<FieldValues, string>, 'onBlur' | 'onChange' | 'value'> &
+  ControllerProps;
 
 export const ControlledOrganizationAutocomplete = ({
   name,
@@ -35,6 +33,7 @@ export const ControlledOrganizationAutocomplete = ({
         <OrganizationAutocomplete
           {...rest}
           FieldProps={{
+            required: typeof rules.required === 'object' ? rules.required.value : !!rules.required,
             ...FieldProps,
             error: !!error,
             helperText: error?.message ? (
@@ -46,7 +45,7 @@ export const ControlledOrganizationAutocomplete = ({
             ) : (
               FieldProps?.helperText
             ),
-            inputRef:ref
+            inputRef: ref,
           }}
           onChange={(event, value, reason) => {
             if (reason === 'clear') {

--- a/packages/controlled-form/src/lib/ProviderAutocomplete.test.tsx
+++ b/packages/controlled-form/src/lib/ProviderAutocomplete.test.tsx
@@ -31,18 +31,18 @@ describe('ControlledProviderAutocomplete', () => {
   test('should loadOptions successfully', async () => {
     const screen = render(
       <QueryClientProvider client={client}>
-        <TestForm UseFormOptions={{values: { controlledAutocomplete: null }}} onSubmit={onSubmit}>
-            <ControlledProviderAutocomplete
-              name="controlledProviderAutocomplete"
-              FieldProps={{
-                label: 'Provider Select',
-                helperText: 'Select a Provider from the list',
-                placeholder: 'Select...',
-                fullWidth: false,
-              }}
-              limit={10}
-              customerId="1234"
-            />
+        <TestForm UseFormOptions={{ values: { controlledAutocomplete: null } }} onSubmit={onSubmit}>
+          <ControlledProviderAutocomplete
+            name="controlledProviderAutocomplete"
+            FieldProps={{
+              label: 'Provider Select',
+              helperText: 'Select a Provider from the list',
+              placeholder: 'Select...',
+              fullWidth: false,
+            }}
+            limit={10}
+            customerId="1234"
+          />
         </TestForm>
       </QueryClientProvider>
     );
@@ -55,20 +55,20 @@ describe('ControlledProviderAutocomplete', () => {
   });
 
   test('should set the value and submit the form data', async () => {
-      const screen = render(
-        <QueryClientProvider client={client}>
-          <TestForm UseFormOptions={{values: { controlledAutocomplete: null }}} onSubmit={onSubmit}>
-            <ControlledProviderAutocomplete
-              name="controlledProviderAutocomplete"
-              FieldProps={{
-                label: 'Provider Select',
-                helperText: 'Select a Provider from the list',
-                placeholder: 'Select...',
-                fullWidth: false,
-              }}
-              limit={10}
-              customerId="1234"
-            />
+    const screen = render(
+      <QueryClientProvider client={client}>
+        <TestForm UseFormOptions={{ values: { controlledAutocomplete: null } }} onSubmit={onSubmit}>
+          <ControlledProviderAutocomplete
+            name="controlledProviderAutocomplete"
+            FieldProps={{
+              label: 'Provider Select',
+              helperText: 'Select a Provider from the list',
+              placeholder: 'Select...',
+              fullWidth: false,
+            }}
+            limit={10}
+            customerId="1234"
+          />
         </TestForm>
       </QueryClientProvider>
     );
@@ -89,6 +89,79 @@ describe('ControlledProviderAutocomplete', () => {
       const controlledProviderAutocompleteValue = JSON.parse(result.innerHTML).controlledProviderAutocomplete;
       expect(controlledProviderAutocompleteValue.uiDisplayName).toBe('Provider 1');
       expect(controlledProviderAutocompleteValue.id).toBeDefined();
+    });
+  });
+
+  describe('when using rules', () => {
+    describe('when required', () => {
+      test('should indicate it is required when passing a string', async () => {
+        const screen = render(
+          <QueryClientProvider client={client}>
+            <TestForm UseFormOptions={{ values: { controlledAutocomplete: null } }} onSubmit={onSubmit}>
+              <ControlledProviderAutocomplete
+                name="controlledProviderAutocomplete"
+                FieldProps={{
+                  label: 'Provider Select',
+                  helperText: 'Select a Provider from the list',
+                  placeholder: 'Select...',
+                  fullWidth: false,
+                }}
+                limit={10}
+                customerId="1234"
+                rules={{ required: 'This field is required' }}
+              />
+            </TestForm>
+          </QueryClientProvider>
+        );
+
+        expect(screen.getByText('*')).toBeDefined();
+      });
+
+      test('should indicate it is required when passing an object with true', async () => {
+        const screen = render(
+          <QueryClientProvider client={client}>
+            <TestForm UseFormOptions={{ values: { controlledAutocomplete: null } }} onSubmit={onSubmit}>
+              <ControlledProviderAutocomplete
+                name="controlledProviderAutocomplete"
+                FieldProps={{
+                  label: 'Provider Select',
+                  helperText: 'Select a Provider from the list',
+                  placeholder: 'Select...',
+                  fullWidth: false,
+                }}
+                limit={10}
+                customerId="1234"
+                rules={{ required: { value: true, message: 'This field is required' } }}
+              />
+            </TestForm>
+          </QueryClientProvider>
+        );
+
+        expect(screen.getByText('*')).toBeDefined();
+      });
+
+      test('should not indicate it is required when passing an object with false', async () => {
+        const screen = render(
+          <QueryClientProvider client={client}>
+            <TestForm UseFormOptions={{ values: { controlledAutocomplete: null } }} onSubmit={onSubmit}>
+              <ControlledProviderAutocomplete
+                name="controlledProviderAutocomplete"
+                FieldProps={{
+                  label: 'Provider Select',
+                  helperText: 'Select a Provider from the list',
+                  placeholder: 'Select...',
+                  fullWidth: false,
+                }}
+                limit={10}
+                customerId="1234"
+                rules={{ required: { value: false, message: 'This field is required' } }}
+              />
+            </TestForm>
+          </QueryClientProvider>
+        );
+
+        expect(screen.queryByText('*')).toBeNull();
+      });
     });
   });
 });

--- a/packages/controlled-form/src/lib/ProviderAutocomplete.tsx
+++ b/packages/controlled-form/src/lib/ProviderAutocomplete.tsx
@@ -2,11 +2,12 @@ import { ProviderAutocomplete, ProviderAutocompleteProps } from '@availity/mui-a
 import { Controller, RegisterOptions, FieldValues } from 'react-hook-form';
 import { ControllerProps } from './Types';
 
-export type ControlledProviderAutocompleteProps = Omit<ProviderAutocompleteProps,
-'onBlur' | 'onChange' | 'value' | 'name'
-> & Pick<RegisterOptions<FieldValues, string>,
-'onBlur' | 'onChange' | 'value'
-> & ControllerProps;
+export type ControlledProviderAutocompleteProps = Omit<
+  ProviderAutocompleteProps,
+  'onBlur' | 'onChange' | 'value' | 'name'
+> &
+  Pick<RegisterOptions<FieldValues, string>, 'onBlur' | 'onChange' | 'value'> &
+  ControllerProps;
 
 export const ControlledProviderAutocomplete = ({
   name,
@@ -35,6 +36,7 @@ export const ControlledProviderAutocomplete = ({
         <ProviderAutocomplete
           {...rest}
           FieldProps={{
+            required: typeof rules.required === 'object' ? rules.required.value : !!rules.required,
             ...FieldProps,
             error: !!error,
             helperText: error?.message ? (

--- a/packages/controlled-form/src/lib/RadioGroup.tsx
+++ b/packages/controlled-form/src/lib/RadioGroup.tsx
@@ -7,12 +7,10 @@ export type ControlledRadioGroupProps = {
   name: string;
   label: string;
   helperText?: string;
-} & Omit <RadioGroupProps,
-'onBlur' | 'onChange' | 'value' | 'name'
-> & Pick<RegisterOptions<FieldValues, string>,
-'onBlur' | 'onChange' | 'value'
-> & ControllerProps
- & Pick<FormControlProps, 'required'>;
+} & Omit<RadioGroupProps, 'onBlur' | 'onChange' | 'value' | 'name'> &
+  Pick<RegisterOptions<FieldValues, string>, 'onBlur' | 'onChange' | 'value'> &
+  ControllerProps &
+  Pick<FormControlProps, 'required'>;
 
 export const ControlledRadioGroup = ({
   name,
@@ -33,8 +31,12 @@ export const ControlledRadioGroup = ({
       defaultValue={defaultValue}
       rules={{ onBlur, onChange, shouldUnregister, value, ...rules }}
       shouldUnregister={shouldUnregister}
-      render={({ field: {disabled, ...field}, fieldState: { error } }) => (
-        <FormControl error={!!error} disabled={disabled} required={!!required}>
+      render={({ field: { disabled, ...field }, fieldState: { error } }) => (
+        <FormControl
+          error={!!error}
+          disabled={disabled}
+          required={!!required || (typeof rules.required === 'object' ? rules.required.value : !!rules.required)}
+        >
           <FormLabel>{label}</FormLabel>
           <RadioGroup {...field} {...rest} />
           <FormHelperText>

--- a/packages/controlled-form/src/lib/Select.tsx
+++ b/packages/controlled-form/src/lib/Select.tsx
@@ -2,11 +2,9 @@ import { Select, SelectProps } from '@availity/mui-form-utils';
 import { RegisterOptions, FieldValues, Controller } from 'react-hook-form';
 import { ControllerProps } from './Types';
 
-export type ControlledSelectProps = Omit<SelectProps,
-'onBlur' | 'onChange' | 'value' | 'name'
-> & Pick<RegisterOptions<FieldValues, string>,
-'onBlur' | 'onChange' | 'value'
-> & ControllerProps;
+export type ControlledSelectProps = Omit<SelectProps, 'onBlur' | 'onChange' | 'value' | 'name'> &
+  Pick<RegisterOptions<FieldValues, string>, 'onBlur' | 'onChange' | 'value'> &
+  ControllerProps;
 
 export const ControlledSelect = ({
   name,
@@ -34,6 +32,7 @@ export const ControlledSelect = ({
       shouldUnregister={shouldUnregister}
       render={({ field, fieldState: { error } }) => (
         <Select
+          required={typeof rules.required === 'object' ? rules.required.value : !!rules.required}
           {...rest}
           {...field}
           error={!!error}

--- a/packages/controlled-form/src/lib/TextField.tsx
+++ b/packages/controlled-form/src/lib/TextField.tsx
@@ -2,11 +2,9 @@ import { TextField, TextFieldProps } from '@availity/mui-textfield';
 import { RegisterOptions, FieldValues, Controller } from 'react-hook-form';
 import { ControllerProps } from './Types';
 
-export type ControlledTextFieldProps = Omit<TextFieldProps,
-'onBlur' | 'onChange' | 'value' | 'name'
-> & Pick<RegisterOptions<FieldValues, string>,
-'onBlur' | 'onChange' | 'value'
-> & ControllerProps;
+export type ControlledTextFieldProps = Omit<TextFieldProps, 'onBlur' | 'onChange' | 'value' | 'name'> &
+  Pick<RegisterOptions<FieldValues, string>, 'onBlur' | 'onChange' | 'value'> &
+  ControllerProps;
 
 export const ControlledTextField = ({
   name,
@@ -33,8 +31,9 @@ export const ControlledTextField = ({
         ...rules,
       }}
       shouldUnregister={shouldUnregister}
-      render={({ field : {ref, ...field}, fieldState: { error } }) => (
+      render={({ field: { ref, ...field }, fieldState: { error } }) => (
         <TextField
+          required={typeof rules.required === 'object' ? rules.required.value : !!rules.required}
           {...field}
           {...rest}
           inputRef={ref}


### PR DESCRIPTION
Fix regression introduced in #666 for using objects for `required` validation (more details about what that means in the original fix: #658)
Fix regression introduced in #666 for passing the `required` property through to underlying `TextField`s

The fixes include supporting the deprecated way of passing `required` directly as well as using the new `rules` object.

Added tests for all of these to prevent future regression.