### PR TITLE
Fix/link load app

### DIFF
--- a/packages/breadcrumbs/src/lib/Breadcrumbs.test.tsx
+++ b/packages/breadcrumbs/src/lib/Breadcrumbs.test.tsx
@@ -130,6 +130,7 @@ describe('Breadcrumbs', () => {
             { name: 'Grand Parent', url: '/grandparent', target: '_self' },
             { name: 'Parent', url: '/grandparent/parent' },
           ]}
+          LinkProps={{ loadApp: false }}
         />
       );
 

--- a/packages/link/src/lib/Link.test.tsx
+++ b/packages/link/src/lib/Link.test.tsx
@@ -126,4 +126,15 @@ describe('Link', () => {
 
     expect(link.getAttribute('class')).toContain('card-link');
   });
+
+  test('should set target to _top when loadApp is true', () => {
+    const { getByRole } = render(
+      <Link href="/public/apps/my-app" loadApp={true} target="_self">
+        My App
+      </Link>
+    );
+
+    const link = getByRole('link');
+    expect(link.getAttribute('target')).toBe('_top');
+  });
 });

--- a/packages/link/src/lib/Link.test.tsx
+++ b/packages/link/src/lib/Link.test.tsx
@@ -137,4 +137,15 @@ describe('Link', () => {
     const link = getByRole('link');
     expect(link.getAttribute('target')).toBe('_top');
   });
+
+  test('should set target when loadApp false and target passed', () => {
+    const { getByRole } = render(
+      <Link href="/public/apps/my-app" loadApp={false} target="_self">
+        My App
+      </Link>
+    );
+
+    const link = getByRole('link');
+    expect(link.getAttribute('target')).toBe('_self');
+  });
 });

--- a/packages/link/src/lib/Link.tsx
+++ b/packages/link/src/lib/Link.tsx
@@ -71,7 +71,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
   return (
     <MuiLink
       href={url}
-      target={target}
+      target={loadApp ? '_top' : target}
       onClick={(event: React.MouseEvent) => onClick && onClick(event, url)}
       rel={rel || setRel(url, target, absolute)}
       {...rest}


### PR DESCRIPTION
Add behavior that whenever `loadApp` is true that we should default the `target` to `_top`. This is because anytime we use `loadApp` we can assume the `Link` is being used inside the nav in the portal.