### PR TITLE
Feat/readonly styles

### DIFF
--- a/packages/autocomplete/src/lib/Autocomplete.stories.tsx
+++ b/packages/autocomplete/src/lib/Autocomplete.stories.tsx
@@ -6,6 +6,7 @@ import { FilterOptionsState } from '@mui/material';
 import { InputAdornment, SearchByFormGroup } from '@availity/mui-form-utils';
 import { TextField } from '@availity/mui-textfield';
 import { SearchIcon } from '@availity/mui-icon';
+import { Stack } from '@availity/mui-layout';
 
 const languages = [
   'Python',
@@ -67,6 +68,26 @@ export const _Multi: StoryObj<typeof Autocomplete> = {
   args: {
     FieldProps: { label: 'Multi Select', helperText: 'Helper Text', fullWidth: false },
     multiple: true,
+  },
+};
+
+export const _States: StoryObj<typeof Autocomplete> = {
+  render: (args) => (
+    <Stack direction="row" sx={{ flexWrap: 'wrap' }}>
+    <Autocomplete {...args} value="Option 1" id="default" FieldProps={{...args.FieldProps, label: "Default"}}/>
+    <Autocomplete {...args} value="Option 1" id="focused" FieldProps={{...args.FieldProps, label: "Focused", focused: true}} />
+    <Autocomplete {...args} value="Option 1" id="error" FieldProps={{...args.FieldProps, label: "Error", error: true}} />
+    <Autocomplete {...args} value="Option 1" id="read-only" FieldProps={{...args.FieldProps, label: "Read Only"}} readOnly />
+    <Autocomplete {...args} value="Option 1" id="disabled" FieldProps={{...args.FieldProps, label: "Disabled"}} disabled />
+    <Autocomplete {...args} multiple value={["Option 1"]} id="default-multiple" FieldProps={{...args.FieldProps, label: "Default Multiple"}}/>
+    <Autocomplete {...args} multiple value={["Option 1"]} id="focused-multiple" FieldProps={{...args.FieldProps, label: "Focused Multiple", focused: true}} />
+    <Autocomplete {...args} multiple value={["Option 1"]} id="error-multiple" FieldProps={{...args.FieldProps, label: "Error Multiple", error: true}} />
+    <Autocomplete {...args} multiple value={["Option 1"]} id="read-only-multiple" FieldProps={{...args.FieldProps, label: "Read Only Multiple"}} readOnly />
+    <Autocomplete {...args} multiple value={["Option 1"]} id="disabled-multiple" FieldProps={{...args.FieldProps, label: "Disabled Multiple"}} disabled />
+    </Stack>
+  ),
+  args: {
+    FieldProps: { helperText: 'Helper Text', fullWidth: false },
   },
 };
 

--- a/packages/datepicker/src/lib/Datepicker.stories.tsx
+++ b/packages/datepicker/src/lib/Datepicker.stories.tsx
@@ -5,7 +5,7 @@ import Typography from '@mui/material/Typography';
 import { MonthCalendar } from '@mui/x-date-pickers/MonthCalendar';
 import { YearCalendar } from '@mui/x-date-pickers/YearCalendar';
 import dayjs, { Dayjs } from 'dayjs';
-import { Box, Grid } from '@availity/mui-layout';
+import { Box, Grid, Stack } from '@availity/mui-layout';
 import { Paper } from '@availity/mui-paper';
 import { Datepicker, DatepickerProps } from './Datepicker';
 import { DateCalendar } from './DateCalendar';
@@ -32,6 +32,26 @@ export const _Datepicker: StoryObj<typeof Datepicker> = {
       />
     );
   },
+  args: {
+    FieldProps: {
+      fullWidth: false,
+      helperText: 'Help text for the field',
+      helpTopicId: '1234',
+      label: 'Date',
+    },
+  },
+};
+
+export const _States: StoryObj<typeof Datepicker> = {
+  render: (args) => (
+    <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }}>
+      <Datepicker {...args} FieldProps={{...args.FieldProps, id: "default", label: "Default"}}/>
+      <Datepicker {...args} FieldProps={{...args.FieldProps, id: "focused", label: "Focused", focused: true}} />
+      <Datepicker {...args} FieldProps={{...args.FieldProps, id: "error", label: "Error", error: true}} />
+      <Datepicker {...args} FieldProps={{...args.FieldProps, id: "read-only", label: "Read Only"}} readOnly />
+      <Datepicker {...args} FieldProps={{...args.FieldProps, id: "disabled", label: "Disabled"}} disabled />
+    </Stack>
+  ),
   args: {
     FieldProps: {
       fullWidth: false,

--- a/packages/textfield/src/lib/TextField.stories.tsx
+++ b/packages/textfield/src/lib/TextField.stories.tsx
@@ -63,12 +63,13 @@ export const _States: StoryObj<typeof TextField> = {
   render: (args: TextFieldProps) => (
     <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }}>
       <TextField label="Default" id="default" {...args} />
-      <TextField label="Focused" id="Focused" focused {...args} />
+      <TextField label="Focused" id="focused" focused {...args} />
       <TextField label="Error" id="error" error {...args} />
+      <TextField label="Read Only" id="read-only" {...args} slotProps={{input: {readOnly: true}}}/>
       <TextField label="Disabled" id="disabled" disabled {...args} />
     </Stack>
   ),
-  args: { margin: 'normal' },
+  args: { margin: 'normal', value: 'value' },
 };
 
 export const _Sizes: StoryObj<typeof TextField> = {

--- a/packages/textfield/src/lib/TextField.tsx
+++ b/packages/textfield/src/lib/TextField.tsx
@@ -131,7 +131,6 @@ export const TextField = forwardRef<HTMLDivElement | HTMLInputElement, TextField
           charCount,
           helperText,
           maxLength,
-          displayOverflowMaxLength,
           showCharacterCount,
         }),
       }}

--- a/packages/textfield/src/lib/TextField.tsx
+++ b/packages/textfield/src/lib/TextField.tsx
@@ -81,6 +81,10 @@ export const TextField = forwardRef<HTMLDivElement | HTMLInputElement, TextField
   // @ts-expect-error I'm not sure why maxLength is undefined in htmlInput, but it works. There's something weird with the type.
   const maxLength = inputProps?.maxLength || rest.slotProps?.htmlInput?.maxLength;
 
+  // @ts-expect-error More htmlInput type issues.
+  // slotProps.input is correct place to pass readOnly for class to be applied, but Autocomplete passes it through deprecated inputProps.
+  const allReadOnly = InputProps?.readOnly || inputProps?.readOnly || rest.slotProps?.htmlInput?.readOnly || rest.slotProps?.input?.readOnly
+
   const resolvedProps = (props: Record<string, unknown>) =>
     !props || Object.keys(props).length === 0 ? undefined : props;
 
@@ -94,7 +98,12 @@ export const TextField = forwardRef<HTMLDivElement | HTMLInputElement, TextField
       helperText={helperText || <></>}
       slots={{ formHelperText: TextFieldFormHelperText }}
       slotProps={{
-        input: resolvedProps({ ...InputProps, ...InputPropOverrides, ...rest.slotProps?.input }),
+        input: resolvedProps({
+          ...InputProps,
+          ...InputPropOverrides,
+          ...rest.slotProps?.input,
+          readOnly: allReadOnly
+        }),
         htmlInput: resolvedProps({
           'aria-required': required,
           ...inputProps,

--- a/packages/theme/src/lib/legacy-theme.ts
+++ b/packages/theme/src/lib/legacy-theme.ts
@@ -1239,11 +1239,8 @@ export const legacyTheme = {
       styleOverrides: {
         root: {
           marginBottom: '.1rem',
-          '&.Mui-error, &.Mui-error.Mui-focused': {
+          '&.Mui-error, &.Mui-error.Mui-focused, &.Mui-disabled': {
             color: tokens.colorTextPrimary,
-          },
-          '&.Mui-disabled': {
-            color: tokens.colorTextDisabled,
           },
           '&.Mui-focused': {
             color: 'inherit',
@@ -1682,8 +1679,9 @@ export const legacyTheme = {
               borderColor: tokens.borderError,
             },
           },
-          '&.Mui-disabled': {
+          '&.Mui-disabled, &.Mui-readOnly': {
             backgroundColor: tokens.colorActionDisabledBg,
+            borderColor: tokens.borderDisabled
           },
         },
         notchedOutline: {

--- a/packages/theme/src/lib/light-theme.ts
+++ b/packages/theme/src/lib/light-theme.ts
@@ -1269,6 +1269,9 @@ export const lightTheme = {
           '.MuiSvgIcon-root': {
             verticalAlign: 'text-bottom',
           },
+          '&.Mui-disabled': {
+            color: tokens.colorTextPrimary,
+          },
         },
       },
     },
@@ -1276,13 +1279,10 @@ export const lightTheme = {
       styleOverrides: {
         root: {
           marginBottom: '3px',
-          '&.Mui-disabled': {
-            color: tokens.colorTextDisabled,
-          },
           '&.Mui-error, &.Mui-error.Mui-focused': {
             color: tokens.colorTextError,
           },
-          '&.Mui-focused': {
+          '&.Mui-focused, &.Mui-disabled': {
             color: tokens.colorTextPrimary,
           },
           // move required asterisk before text
@@ -1364,6 +1364,9 @@ export const lightTheme = {
               '&.Mui-disabled > fieldset': {
                 borderColor: tokens.borderDisabled,
                 color: tokens.colorTextDisabled,
+              },
+              '&.Mui-readOnly, > input[readonly]': {
+                backgroundColor: tokens.colorActionReadonlyBg
               },
               '.MuiInputBase-input': {
                 padding: '8px 12px',


### PR DESCRIPTION
fun fact, datepicker passes readonly correctly to utilize the read-only class. Did I know said read-only class existed when working on Textfield/Autocomplete? nope. Struggled through a completely custom solution till datepicker showed the error of my ways. kmn.

Also removed the extra displayOverflowMaxLength :)