### PR TITLE
fix(mui-spaces): don't check for sso type on rendered apps with ssoId

### DIFF
--- a/packages/spaces/package.json
+++ b/packages/spaces/package.json
@@ -84,7 +84,7 @@
     "@availity/api-axios": "^11.0.0",
     "@availity/hooks": "^5.1.5",
     "@availity/message-core": "^8.0.0",
-    "@availity/native-form": "^7.0.0",
+    "@availity/native-form": "^7.0.1",
     "@availity/resolve-url": "^4.0.0",
     "@tanstack/react-query": "^4.36.1",
     "dayjs": "^1.11.13",

--- a/packages/spaces/src/lib/Spaces.tsx
+++ b/packages/spaces/src/lib/Spaces.tsx
@@ -4,7 +4,6 @@ import { spacesReducer, fetchAllSpaces } from './spaces-data';
 import configurationFindMany from './configurationFindMany';
 import { ModalProvider } from './modals/ModalProvider';
 import type { Space, SpacesProps, SpacesContextType, UseSpaces } from './spaces-types';
-import type { SsoTypeSpace } from './SpacesLink/spaces-link-types';
 import { isReactNodeFunction } from './helpers';
 
 export const INITIAL_STATE = {
@@ -206,7 +205,7 @@ export const useSpaces: UseSpaces = (...ids) => {
     return spaces && [...spaces.values()];
   }
 
-  return ids.reduce((acc: (Space | SsoTypeSpace)[], id) => {
+  return ids.reduce((acc: (Space)[], id) => {
     const matchedSpace = spaces?.get(id) || spacesByConfig?.get(id);
 
     if (matchedSpace) {

--- a/packages/spaces/src/lib/SpacesLink/spaces-link-types.tsx
+++ b/packages/spaces/src/lib/SpacesLink/spaces-link-types.tsx
@@ -14,7 +14,7 @@ export type SpacesLinkWithSpace = {
    * This component does not have to be a child of SpacesProvider.
    * Note: If you are wanting to take advantage of the sso links you will additionally need to pass the clientId in.
    */
-  space: Space | SsoTypeSpace;
+  space: Space;
 } & SpacesLinkProps;
 
 export type SpacesLinkWithSpaceId = {
@@ -26,7 +26,7 @@ export type SpacesLinkWithSpaceId = {
    * This component does not have to be a child of SpacesProvider.
    * Note: If you are wanting to take advantage of the sso links you will additionally need to pass the clientId in.
    */
-  space?: Space | SsoTypeSpace;
+  space?: Space;
 } & SpacesLinkProps;
 
 export type SpacesLinkProps = {
@@ -111,13 +111,9 @@ export type MediaProps = {
   onKeyDown?: (event: React.KeyboardEvent) => void;
 };
 
-export interface SsoTypeSpace extends Space {
-  type: 'saml' | 'openid';
-}
-
 export type UseLink = {
   (
-    spaceId?: Space | SsoTypeSpace | string,
+    spaceId?: Space | string,
     options?: { clientId?: string; linkAttributes?: Record<string, any> }
   ): [Space | undefined, MediaProps | undefined];
 };
@@ -134,7 +130,7 @@ export type OpenLink = {
 
 export type OpenLinkWithSso = {
   (
-    space: SsoTypeSpace | Space,
+    space: Space,
     params: {
       akaname?: string;
       clientId: string;

--- a/packages/spaces/src/lib/SpacesLink/spaces-link-types.tsx
+++ b/packages/spaces/src/lib/SpacesLink/spaces-link-types.tsx
@@ -134,7 +134,7 @@ export type OpenLink = {
 
 export type OpenLinkWithSso = {
   (
-    space: SsoTypeSpace,
+    space: SsoTypeSpace | Space,
     params: {
       akaname?: string;
       clientId: string;

--- a/packages/spaces/src/lib/SpacesLink/useLink.test.tsx
+++ b/packages/spaces/src/lib/SpacesLink/useLink.test.tsx
@@ -4,14 +4,13 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Spaces } from '../Spaces';
 import { SpacesLink } from './SpacesLink';
 import type { Space } from '../spaces-types';
-import type { SsoTypeSpace } from './spaces-link-types';
 
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { server } from '@availity/mock/src/lib/server';
 
 jest.mock('@availity/native-form');
 
-const buildSpacesLink = (space: Space | SsoTypeSpace, linkAttributes: Record<any, any>) => {
+const buildSpacesLink = (space: Space, linkAttributes: Record<any, any>) => {
   const queryClient = new QueryClient();
   return (
     <QueryClientProvider client={queryClient}>
@@ -44,7 +43,7 @@ describe('useLink', () => {
     server.resetHandlers();
   });
 
-  const space: Space | SsoTypeSpace = {
+  const space: Space = {
     type: 'APPLICATION',
     name: 'an application',
     description: 'This is an application',

--- a/packages/spaces/src/lib/SpacesLink/useLink.tsx
+++ b/packages/spaces/src/lib/SpacesLink/useLink.tsx
@@ -2,11 +2,7 @@ import { useCurrentUser } from '@availity/hooks';
 import { useSpaces } from '../Spaces';
 import { useModal } from '../modals/ModalProvider';
 import { openLink, openLinkWithSso } from './linkHandlers';
-import type { UseLink, MediaProps, SsoTypeSpace } from './spaces-link-types';
-import { Space } from '../spaces-types';
-
-const isSsoSpace = (space: Space | SsoTypeSpace | undefined): space is SsoTypeSpace =>
-  space?.type === 'saml' || space?.type === 'openid';
+import type { UseLink, MediaProps } from './spaces-link-types';
 
 export const useLink: UseLink = (spaceOrSpaceId, options) => {
   const spaceFromSpacesProvider = useSpaces(
@@ -56,7 +52,7 @@ export const useLink: UseLink = (spaceOrSpaceId, options) => {
     role: 'link',
   };
 
-  if (isSsoSpace(space) && space?.meta?.ssoId) {
+  if (space?.meta?.ssoId) {
     if (!options?.clientId) {
       throw new Error('clientId is required for SSO spaces');
     }

--- a/packages/spaces/src/lib/spaces-types.tsx
+++ b/packages/spaces/src/lib/spaces-types.tsx
@@ -1,5 +1,3 @@
-import { SsoTypeSpace } from './SpacesLink/spaces-link-types';
-
 export type Link = {
   /** Contains a URL or URL Fragment that the hyperlink points to. */
   url?: string;
@@ -83,7 +81,7 @@ export type FetchAllSpacesProps = {
 
 export type SpacesContextType = {
   /** Array of spaces to be passed into the Spaces provider. */
-  spaces?: Map<string, Space | SsoTypeSpace>;
+  spaces?: Map<string, Space>;
   /** Array of spaces from previous page load. */
   previousSpacesMap?: Map<string, Space>;
   /** Array of spaces organized by configurationId. */
@@ -135,4 +133,4 @@ export type SpacesProps = {
   spaces?: Space[];
 };
 
-export type UseSpaces = (...ids: string[]) => (Space | SsoTypeSpace)[] | undefined;
+export type UseSpaces = (...ids: string[]) => (Space)[] | undefined;


### PR DESCRIPTION
Let native-form check the ssoId for saml or openid, becuase the saml/openid is a different config from the application/resource/etc that is rendered that contains ssoId metadata