### PR TITLE
refactor(mui-spaces): account for spaces-ui hosted in essentials

### DIFF
--- a/packages/spaces/src/lib/SpacesLink/linkHandlers.tsx
+++ b/packages/spaces/src/lib/SpacesLink/linkHandlers.tsx
@@ -20,7 +20,7 @@ export const openLink: OpenLink = async (space, params) => {
 
   let url = !isAbsoluteUrl(space.link.url) ? getUrl(urlWithParams, false, false) : urlWithParams;
 
-  if (!isAbsoluteUrl(url) && essentialsDomainRegex.test(window.location.origin)) {
+  if (!isAbsoluteUrl(url) && essentialsDomainRegex.test(window.location.origin) && /\/public\/spaces/.test(url)) {
     const appsDomain = window.location.origin.replace("essentials", "apps");
     url = `${appsDomain}${url}`
   }

--- a/packages/spaces/src/lib/SpacesLink/linkHandlers.tsx
+++ b/packages/spaces/src/lib/SpacesLink/linkHandlers.tsx
@@ -12,10 +12,18 @@ export const openLink: OpenLink = async (space, params) => {
   if (params?.akaname) await updateTopApps(space, params.akaname);
 
   const spaceId = params?.payerSpaceId || space.parents?.[0]?.id;
+
+  const essentialsDomainRegex = /(test|qa(p?)-)?essentials\.availity\.com/;
   const needsSpaceId =
-    !isAbsoluteUrl(space.link.url) || /(test|qa(p?)-)?essentials\.availity\.com/.test(space.link.url);
+    !isAbsoluteUrl(space.link.url) || essentialsDomainRegex.test(space.link.url);
   const urlWithParams = needsSpaceId ? updateUrl(space.link.url, 'spaceId', spaceId) : space.link.url;
-  const url = !isAbsoluteUrl(space.link.url) ? getUrl(urlWithParams, false, false) : urlWithParams;
+
+  let url = !isAbsoluteUrl(space.link.url) ? getUrl(urlWithParams, false, false) : urlWithParams;
+
+  if (!isAbsoluteUrl(url) && essentialsDomainRegex.test(window.location.origin)) {
+    const appsDomain = window.location.origin.replace("essentials", "apps");
+    url = `${appsDomain}${url}`
+  }
 
   const target = getTarget(space.link.target);
 

--- a/packages/spaces/src/lib/SpacesLink/linkHandlers.tsx
+++ b/packages/spaces/src/lib/SpacesLink/linkHandlers.tsx
@@ -20,7 +20,7 @@ export const openLink: OpenLink = async (space, params) => {
 
   let url = !isAbsoluteUrl(space.link.url) ? getUrl(urlWithParams, false, false) : urlWithParams;
 
-  if (!isAbsoluteUrl(url) && essentialsDomainRegex.test(window.location.origin) && /\/public\/spaces/.test(url)) {
+  if (!isAbsoluteUrl(url) && essentialsDomainRegex.test(window.location.origin) && /\/web\/|\/public\/(apps|spaces)/.test(url)) {
     const appsDomain = window.location.origin.replace("essentials", "apps");
     url = `${appsDomain}${url}`
   }

--- a/packages/spaces/src/lib/SpacesLink/useLink.test.tsx
+++ b/packages/spaces/src/lib/SpacesLink/useLink.test.tsx
@@ -296,7 +296,7 @@ describe('useLink', () => {
 
     space.id = '11';
     space.configurationId = '11';
-    space.link = { text: 'the link', target: '_self', url: '/path/to/url' };
+    space.link = { text: 'the link', target: '_self', url: '/public/spaces/url' };
     space.type = 'APPLICATION';
     space.meta = {};
 
@@ -307,7 +307,7 @@ describe('useLink', () => {
     if (linkHeader11) fireEvent.click(linkHeader11);
 
     await waitFor(() => {
-      expect(window.open).toHaveBeenCalledWith('https://test-apps.availity.com/path/to/url?spaceId=11', '_self');
+      expect(window.open).toHaveBeenCalledWith('https://test-apps.availity.com/public/spaces/url?spaceId=11', '_self');
       expect(nativeForm).not.toHaveBeenCalled();
     });
   });

--- a/packages/spaces/src/lib/SpacesLink/useLink.test.tsx
+++ b/packages/spaces/src/lib/SpacesLink/useLink.test.tsx
@@ -29,6 +29,8 @@ const buildSpacesLink = (space: Space, linkAttributes: Record<any, any>) => {
   );
 };
 
+const originalWindowLocation = window.location;
+
 describe('useLink', () => {
   beforeAll(() => {
     // Start the interception.
@@ -38,9 +40,14 @@ describe('useLink', () => {
     Object.defineProperty(window, 'open', { value: jest.fn() });
   });
   afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: originalWindowLocation,
+    });
     jest.clearAllMocks();
     cleanup();
     server.resetHandlers();
+
   });
 
   const space: Space = {
@@ -282,8 +289,6 @@ describe('useLink', () => {
 
   it('should replace essentials with apps for onprem', async () => {
     Object.defineProperty(window, 'location', {
-      configurable: true,
-      enumerable: true,
       value: new URL("https://test-essentials.availity.com"),
     });
 

--- a/packages/spaces/src/lib/SpacesLink/useLink.test.tsx
+++ b/packages/spaces/src/lib/SpacesLink/useLink.test.tsx
@@ -29,8 +29,6 @@ const buildSpacesLink = (space: Space, linkAttributes: Record<any, any>) => {
   );
 };
 
-const originalWindowLocation = window.location;
-
 describe('useLink', () => {
   beforeAll(() => {
     // Start the interception.
@@ -43,11 +41,6 @@ describe('useLink', () => {
     jest.clearAllMocks();
     cleanup();
     server.resetHandlers();
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      enumerable: true,
-      value: originalWindowLocation,
-    });
   });
 
   const space: Space = {


### PR DESCRIPTION
Spaces UI is migrating to essentials so need to handle on prem relative URLs by converting them to absolute URLs