### PR TITLE
feat(mui-datepicker): replace action bar clear button with input adornment

### DIFF
--- a/packages/controlled-form/src/lib/Types.tsx
+++ b/packages/controlled-form/src/lib/Types.tsx
@@ -427,6 +427,7 @@ export const DatepickerPropsCategorized: DatepickerPropsObject = {
   disableOpenPicker: { table: { category: 'Input Props' } },
   placement: { table: { category: 'Input Props' } },
   clearable: { table: { category: 'Input Props' } },
+  onClear: { table: { category: 'Input Props' } }
 };
 
 export const CodesAutocompletePropsCategorized: CodesAutocompletePropsObject = {

--- a/packages/datepicker/src/lib/Datepicker.tsx
+++ b/packages/datepicker/src/lib/Datepicker.tsx
@@ -4,7 +4,7 @@ import { DatePicker as MuiDatePicker, DatePickerProps as MuiDatePickerProps } fr
 import type { Dayjs } from 'dayjs';
 import type {} from '@mui/x-date-pickers/AdapterDayjs';
 import { PickersTextField as MuiPickersTextField, PickersTextFieldProps as MuiPickersTextFieldProps } from '@mui/x-date-pickers/PickersTextField';
-import { PickerFieldUISlotProps } from '@mui/x-date-pickers/internals';
+import { ExportedPickerFieldUIProps, PickerFieldUISlotProps } from '@mui/x-date-pickers/internals';
 import { FormHelperText, FormLabel, InputPropOverrides } from '@availity/mui-form-utils';
 import { forwardRef } from 'react';
 
@@ -18,9 +18,8 @@ export type DatepickerProps = {
    * @default bottom-start
    */
   placement?: 'bottom-start' | 'bottom' | 'bottom-end';
-  /** Determines if the clear button appears in the action bar */
-  clearable?: boolean;
-} & Omit<
+} & Pick<ExportedPickerFieldUIProps, 'onClear' | 'clearable'>
+  & Omit<
   MuiDatePickerProps<false>,
   | 'components'
   | 'componentsProps'
@@ -76,6 +75,7 @@ export const Datepicker = ({
   FieldProps,
   placement = 'bottom-start',
   clearable,
+  onClear,
   ...props
 }: DatepickerProps): React.JSX.Element => {
   return (
@@ -83,15 +83,13 @@ export const Datepicker = ({
       {...props}
       dayOfWeekFormatter={(weekday: Dayjs) => weekday.format('dd')}
       slotProps={{
-        actionBar: {
-          actions: clearable ? ['clear'] : [],
-        },
         desktopPaper: paperProps,
         mobilePaper: {
           ...paperProps,
           'aria-label': FieldProps?.label?.toString() || FieldProps?.inputProps?.['aria-label'] || 'Date picker',
           'aria-labelledby': FieldProps?.inputProps?.['aria-labelledby'] || undefined,
         },
+        field: { clearable, onClear },
         textField: FieldProps,
         popper: {
           placement,

--- a/packages/theme/src/lib/light-theme.ts
+++ b/packages/theme/src/lib/light-theme.ts
@@ -1858,6 +1858,10 @@ export const lightTheme = {
             // padding: '8px',
             color: tokens.colorGrey400,
           },
+          '.MuiInputAdornment-root .MuiIconButton-root': {
+            width: '2.25rem',
+            height: '2.25rem',
+          },
         },
       },
     },


### PR DESCRIPTION
datepicker `clearable` prop would now add input adornment clear button, removing the calendar action bar clear button. Was originally planning to keep both during transition but the new `onClear` does not get passed to the action bar clear button and don't want differing behaviors.

It's now March, in theory the next version of mui should be coming out soon-ish. Is this breaking enough to merit waiting until then? If so we can add to the v3 milestone.