### PR TITLE
fix(element): add build step before lint in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,9 @@ jobs:
           restore-keys: |
             nx-${{ runner.os }}-${{ hashFiles('yarn.lock') }}-
 
+      - name: Build Packages
+        run: yarn build
+
       - name: Lint Affected Code
         run: yarn lint:affected
 


### PR DESCRIPTION
The eslint-import-resolver-typescript resolver uses package.json exports to find type declarations at ./dist/index.d.ts. Without a build step, those files don't exist and import/no-unresolved fires for workspace deps.

This matches the pr-build.yml workflow which already builds before linting.