### PR TITLE
Fix/tooltip typo and status chip test

### DIFF
--- a/packages/chip/src/lib/StatusChip.test.tsx
+++ b/packages/chip/src/lib/StatusChip.test.tsx
@@ -1,9 +1,9 @@
 import { render } from '@testing-library/react';
-import { Chip } from './Chip';
+import { StatusChip } from './StatusChip';
 
-describe('Chip', () => {
+describe('StatusChip', () => {
   test('should render successfully', () => {
-    const { getByText } = render(<Chip label="Test" />);
+    const { getByText } = render(<StatusChip label="Test" />);
     expect(getByText('Test')).toBeTruthy();
   });
 });

--- a/packages/tooltip/src/lib/Tooltip.stories.tsx
+++ b/packages/tooltip/src/lib/Tooltip.stories.tsx
@@ -53,7 +53,7 @@ const argTypes = {
     },
   },
   leaveDelay: {
-    description: 'Delay before the tooltip is hidden. (micro seconds)',
+    description: 'Delay before the tooltip is hidden. (milliseconds)',
     control: { type: 'number' },
     table: { type: { summary: 'number' } },
     defaultValue: { summary: 0 },


### PR DESCRIPTION

Added minor fixes for 
1. mui-tooltip : typo in leaveDelay description (micro seconds → milliseconds)
2. mui-chip: replace StatusChip test importing wrong component. (Chip -> StatusChip)